### PR TITLE
Fix LockAudio/UnlockAudio implementations for n3ds

### DIFF
--- a/src/audio/n3ds/SDL_n3dsaudio.c
+++ b/src/audio/n3ds/SDL_n3dsaudio.c
@@ -67,12 +67,12 @@ static inline void contextUnlock(_THIS)
 
 static void N3DSAUD_LockAudio(_THIS)
 {
-	contextLock(this);
+	SDL_mutexP(this->mixer_lock);
 }
 
 static void N3DSAUD_UnlockAudio(_THIS)
 {
-	contextUnlock(this);
+	SDL_mutexV(this->mixer_lock);
 }
 
 static void N3DSAUD_DeleteDevice(SDL_AudioDevice *device)


### PR DESCRIPTION
## Description
This PR simply modifies the LockAudio and UnlockAudio implementations in the n3ds driver to use the audio device's `mixer_lock` instead of the private `LightLock` used by some of the other functions in the driver.

The idea here is to satisfy the guarantee that the callback is not running while the audio lock is taken. Since that seems to be the sole purpose of the `SDL_LockAudio()` and `SDL_UnlockAudio()` functions, these functions shouldn't need to be synchronized with any of the other functions in the driver so I believe the private `LightLock` is unnecessary here.

Since the default implementation of the `SDL_LockAudio()` and `SDL_UnlockAudio()` functions also use the audio device's `mixer_lock`, my first thought was to instead remove the driver implementations completely. However, I still ran into problems when I tried it because the default implementation does some comparisons using `SDL_ThreadID()` for which the n3ds port has an incompatible implementation.

## Existing Issue(s)
This resolves #13