### PR TITLE
[Replaced by #23] Switch Audio: Added Audio Out usage and touchscreen code rework

### DIFF
--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -102,7 +102,8 @@ static const AudioBootStrap *const bootstrap[] = {
     &EMSCRIPTENAUDIO_bootstrap,
 #endif
 #if SDL_AUDIO_DRIVER_SWITCH
-    &SWITCHAUDIO_bootstrap,
+    &SWITCHAUDIOOUT_bootstrap,
+    &SWITCHAUDIOREN_bootstrap,
 #endif
 #if SDL_AUDIO_DRIVER_JACK
     &JACK_bootstrap,
@@ -1683,7 +1684,7 @@ SDL_SilenceValueForFormat(const SDL_AudioFormat format)
             return 0x80;
 
         default: break;
-    }            
+    }
 
     return 0x00;
 }

--- a/src/audio/SDL_sysaudio.h
+++ b/src/audio/SDL_sysaudio.h
@@ -208,7 +208,8 @@ extern AudioBootStrap ANDROIDAUDIO_bootstrap;
 extern AudioBootStrap PSPAUDIO_bootstrap;
 extern AudioBootStrap EMSCRIPTENAUDIO_bootstrap;
 extern AudioBootStrap OS2AUDIO_bootstrap;
-extern AudioBootStrap SWITCHAUDIO_bootstrap;
+extern AudioBootStrap SWITCHAUDIOOUT_bootstrap;
+extern AudioBootStrap SWITCHAUDIOREN_bootstrap;
 
 #endif /* SDL_sysaudio_h_ */
 

--- a/src/audio/switch/SDL_switchaudio.c
+++ b/src/audio/switch/SDL_switchaudio.c
@@ -173,6 +173,7 @@ SWITCHAUDIO_PlayDevice(_THIS)
 static void
 SWITCHAUDIO_WaitDevice(_THIS)
 {
+    (void)this;
 }
 
 static Uint8
@@ -202,7 +203,7 @@ SWITCHAUDIO_CloseDevice(_THIS)
 static void
 SWITCHAUDIO_ThreadInit(_THIS)
 {
-
+    (void)this;
 }
 
 static int
@@ -220,8 +221,8 @@ SWITCHAUDIO_Init(SDL_AudioDriverImpl *impl)
     return 1;
 }
 
-AudioBootStrap SWITCHAUDIO_bootstrap = {
-    "switch", "Nintendo Switch audio driver", SWITCHAUDIO_Init, 0
+AudioBootStrap SWITCHAUDIOREN_bootstrap = {
+    "switch", "Nintendo Switch audio render driver", SWITCHAUDIO_Init, 0
 };
 
 #endif /* SDL_AUDIO_DRIVER_SWITCH */

--- a/src/audio/switch/SDL_switchaudioout.c
+++ b/src/audio/switch/SDL_switchaudioout.c
@@ -1,0 +1,189 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2018 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+#include "../../SDL_internal.h"
+
+#if SDL_AUDIO_DRIVER_SWITCH
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <malloc.h>
+
+#include "SDL_audio.h"
+#include "../SDL_audio_c.h"
+#include "../SDL_audiodev_c.h"
+
+#include "SDL_switchaudioout.h"
+
+static int
+SWITCHAUDIO_OpenDevice(_THIS, void *handle, const char *devname, int iscapture)
+{
+    Result res;
+    PcmFormat fmt;
+    int mixlen, aligned_size, i;
+
+    this->hidden = (struct SDL_PrivateAudioData *) SDL_malloc(sizeof(*this->hidden));
+    if (this->hidden == NULL) {
+        return SDL_OutOfMemory();
+    }
+    SDL_zerop(this->hidden);
+
+    res = audoutInitialize();
+    if (R_FAILED(res)) {
+        SDL_free(this->hidden);
+        this->hidden = NULL;
+        return SDL_SetError("audoutInitialize failed (0x%x)", res);
+    }
+
+    fmt = audoutGetPcmFormat();
+    switch (fmt) {
+    case PcmFormat_Invalid:
+        SDL_free(this->hidden);
+        this->hidden = NULL;
+        return SDL_SetError("audoutGetPcmFormat returned invalid value (0x%x)", (int)fmt);
+    case PcmFormat_Int8:
+        this->spec.format = AUDIO_S8;
+        break;
+    case PcmFormat_Int16:
+        this->spec.format = AUDIO_S16SYS;
+        break;
+    case PcmFormat_Int32:
+        this->spec.format = AUDIO_S32SYS;
+        break;
+    case PcmFormat_Float:
+        this->spec.format = AUDIO_F32SYS;
+        break;
+    case PcmFormat_Int24:
+    case PcmFormat_Adpcm:
+        SDL_free(this->hidden);
+        this->hidden = NULL;
+        return SDL_SetError("audoutGetPcmFormat returned unsupported sample format (0x%x)", (int)fmt);
+        break;
+    }
+
+    this->spec.freq = (int)audoutGetSampleRate();
+    this->spec.channels = audoutGetChannelCount();
+
+    SDL_CalculateAudioSpec(&this->spec);
+
+    aligned_size = (this->spec.size + 0xfff) & ~0xfff;
+    mixlen = aligned_size * NUM_BUFFERS;
+
+    this->hidden->rawbuf = memalign(0x1000, mixlen);
+    if (this->hidden->rawbuf == NULL) {
+        SDL_free(this->hidden);
+        this->hidden = NULL;
+        return SDL_SetError("Couldn't allocate mixing buffer");
+    }
+
+    SDL_memset(this->hidden->rawbuf, 0, mixlen);
+    for (i = 0; i < NUM_BUFFERS; i++) {
+        this->hidden->out_buffers[i] = &this->hidden->rawbuf[i * aligned_size];
+        this->hidden->buffer[i].next = NULL;
+        this->hidden->buffer[i].buffer = this->hidden->out_buffers[i];
+        this->hidden->buffer[i].buffer_size = aligned_size;
+        this->hidden->buffer[i].data_size = this->spec.size;
+        this->hidden->buffer[i].data_offset = 0;
+    }
+
+    this->hidden->cur_buffer = this->hidden->next_buffer;
+    this->hidden->next_buffer = (this->hidden->next_buffer + 1) % NUM_BUFFERS;
+
+    res = audoutStartAudioOut();
+    if (R_FAILED(res)) {
+        free(this->hidden->rawbuf);
+        this->hidden->rawbuf = NULL;
+        SDL_free(this->hidden);
+        this->hidden = NULL;
+        return SDL_SetError("audoutStartAudioOut failed (0x%x)", res);
+    }
+
+    res = audoutAppendAudioOutBuffer(&this->hidden->buffer[this->hidden->cur_buffer]);
+    if (R_FAILED(res)) {
+        free(this->hidden->rawbuf);
+        this->hidden->rawbuf = NULL;
+        SDL_free(this->hidden);
+        this->hidden = NULL;
+        return SDL_SetError("audoutAppendAudioOutBuffer failed (0x%x)", res);
+    }
+
+    return 0;
+}
+
+static void
+SWITCHAUDIO_PlayDevice(_THIS)
+{
+    this->hidden->cur_buffer = this->hidden->next_buffer;
+    audoutAppendAudioOutBuffer(&this->hidden->buffer[this->hidden->cur_buffer]);
+    this->hidden->next_buffer = (this->hidden->next_buffer + 1) % NUM_BUFFERS;
+}
+
+static void
+SWITCHAUDIO_WaitDevice(_THIS)
+{
+    audoutWaitPlayFinish(&this->hidden->released_out_buffer, &this->hidden->released_out_count, UINT64_MAX);
+}
+
+static Uint8
+*SWITCHAUDIO_GetDeviceBuf(_THIS)
+{
+    return this->hidden->out_buffers[this->hidden->next_buffer];
+}
+
+static void
+SWITCHAUDIO_CloseDevice(_THIS)
+{
+    audoutStopAudioOut();
+
+    if (this->hidden->rawbuf) {
+        free(this->hidden->rawbuf);
+        this->hidden->rawbuf = NULL;
+    }
+
+    SDL_free(this->hidden);
+}
+
+static void
+SWITCHAUDIO_ThreadInit(_THIS)
+{
+    (void)this;
+}
+
+static int
+SWITCHAUDIO_Init(SDL_AudioDriverImpl *impl)
+{
+    impl->OpenDevice = SWITCHAUDIO_OpenDevice;
+    impl->PlayDevice = SWITCHAUDIO_PlayDevice;
+    impl->WaitDevice = SWITCHAUDIO_WaitDevice;
+    impl->GetDeviceBuf = SWITCHAUDIO_GetDeviceBuf;
+    impl->CloseDevice = SWITCHAUDIO_CloseDevice;
+    impl->ThreadInit = SWITCHAUDIO_ThreadInit;
+
+    impl->OnlyHasDefaultOutputDevice = SDL_TRUE;
+
+    return SDL_TRUE;
+}
+
+AudioBootStrap SWITCHAUDIOOUT_bootstrap = {
+    "switchout", "Nintendo Switch audio out driver", SWITCHAUDIO_Init, SDL_FALSE
+};
+
+#endif /* SDL_AUDIO_DRIVER_SWITCH */

--- a/src/audio/switch/SDL_switchaudioout.c
+++ b/src/audio/switch/SDL_switchaudioout.c
@@ -107,15 +107,6 @@ SWITCHAUDIO_OpenDevice(_THIS, void *handle, const char *devname, int iscapture)
     this->hidden->cur_buffer = this->hidden->next_buffer;
     this->hidden->next_buffer = (this->hidden->next_buffer + 1) % NUM_BUFFERS;
 
-    res = audoutStartAudioOut();
-    if (R_FAILED(res)) {
-        free(this->hidden->rawbuf);
-        this->hidden->rawbuf = NULL;
-        SDL_free(this->hidden);
-        this->hidden = NULL;
-        return SDL_SetError("audoutStartAudioOut failed (0x%x)", res);
-    }
-
     res = audoutAppendAudioOutBuffer(&this->hidden->buffer[this->hidden->cur_buffer]);
     if (R_FAILED(res)) {
         free(this->hidden->rawbuf);
@@ -123,6 +114,15 @@ SWITCHAUDIO_OpenDevice(_THIS, void *handle, const char *devname, int iscapture)
         SDL_free(this->hidden);
         this->hidden = NULL;
         return SDL_SetError("audoutAppendAudioOutBuffer failed (0x%x)", res);
+    }
+
+    res = audoutStartAudioOut();
+    if (R_FAILED(res)) {
+        free(this->hidden->rawbuf);
+        this->hidden->rawbuf = NULL;
+        SDL_free(this->hidden);
+        this->hidden = NULL;
+        return SDL_SetError("audoutStartAudioOut failed (0x%x)", res);
     }
 
     return 0;

--- a/src/audio/switch/SDL_switchaudioout.h
+++ b/src/audio/switch/SDL_switchaudioout.h
@@ -1,0 +1,48 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2018 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef SDL_switchaudio_h_
+#define SDL_switchaudio_h_
+
+#include <switch.h>
+#include "../SDL_sysaudio.h"
+
+/* Hidden "this" pointer for the audio functions */
+#define _THIS   SDL_AudioDevice *this
+
+#define NUM_BUFFERS 2
+
+struct SDL_PrivateAudioData
+{
+    AudioOutBuffer buffer[NUM_BUFFERS];
+    AudioOutBuffer *released_out_buffer;
+    u32 released_out_count;
+    /* The raw allocated mixing buffer. */
+    Uint8   *rawbuf;
+    /* Individual mixing buffers. */
+    void *out_buffers[NUM_BUFFERS];
+    /* Index of the next available mixing buffer. */
+    int     next_buffer;
+    /* Currently playing buffer */
+    int     cur_buffer;
+};
+
+#endif /* SDL_switchaudio_h_ */

--- a/src/video/switch/SDL_switchtouch.c
+++ b/src/video/switch/SDL_switchtouch.c
@@ -29,59 +29,89 @@
 #include "../../events/SDL_touch_c.h"
 #include "../../video/SDL_sysvideo.h"
 
-HidTouchScreenState touchState;
-HidTouchScreenState touchStateOld;
+static HidTouchScreenState touchState;
+static HidTouchScreenState touchStateOld;
 
-void
-SWITCH_InitTouch(void) {
+void SWITCH_InitTouch(void)
+{
     hidInitializeTouchScreen();
     SDL_AddTouch((SDL_TouchID) 0, SDL_TOUCH_DEVICE_DIRECT, "Switch");
     SDL_SetHintWithPriority(SDL_HINT_TOUCH_MOUSE_EVENTS, "0", SDL_HINT_DEFAULT);
+    SDL_memset(&touchState, 0, sizeof(HidTouchScreenState));
+    SDL_memset(&touchStateOld, 0, sizeof(HidTouchScreenState));
 }
 
-void
-SWITCH_QuitTouch(void) {
-
+void SWITCH_QuitTouch(void)
+{
 }
 
-void
-SWITCH_PollTouch(void) {
+void SWITCH_PollTouch(void)
+{
+    const float rel_w = 1280.0f, rel_h = 720.0f;
     SDL_Window *window = SDL_GetFocusWindow();
-    if (window == NULL) {
+    SDL_TouchID id = 1;
+    SDL_bool found;
+    s32 i, j;
+
+    if (!window) {
         return;
     }
 
-    memcpy(&touchStateOld, &touchState, sizeof(touchState));
+    if (SDL_AddTouch(id, SDL_TOUCH_DEVICE_DIRECT, "") < 0) {
+        SDL_Log("error: can't add touch %s, %d", __FILE__, __LINE__);
+    }
+
+    SDL_memcpy(&touchStateOld, &touchState, sizeof(touchState));
 
     if (hidGetTouchScreenStates(&touchState, 1)) {
-        for (u32 i = 0; i < touchState.count; i++) {
-            // Send an initial touch
-            SDL_SendTouch(0, touchState.touches[i].finger_id, window, SDL_TRUE,
-                          (float) touchState.touches[i].x / 1280.0f,
-                          (float) touchState.touches[i].y / 720.0f, 1);
-            // Always send the motion
-            SDL_SendTouchMotion(0, (SDL_FingerID) i, window,
-                                (float) touchState.touches[i].x / 1280.0f,
-                                (float) touchState.touches[i].y / 720.0f, 1);
-        }
+        /* Finger down */
+        if (touchStateOld.count < touchState.count) {
+            for (i = 0; i < touchState.count; i++) {
+                found = SDL_FALSE;
 
-        // some fingers might have been let go
-        if (touchStateOld.count > 0) {
-            for (int i = 0; i < touchStateOld.count; i++) {
-                int finger_up = 1;
-                if (touchState.count > 0) {
-                    for (int j = 0; j < touchState.count; j++) {
-                        if (touchState.touches[j].finger_id == touchStateOld.touches[i].finger_id) {
-                            finger_up = 0;
-                        }
+                for (j = 0; j < touchStateOld.count; j++) {
+                    if (touchStateOld.touches[j].finger_id == touchState.touches[i].finger_id) {
+                        found = SDL_TRUE;
+                        break;
                     }
                 }
-                if (finger_up == 1) {
-                    // Finger released from screen
-                    SDL_SendTouch((SDL_TouchID) 0, (SDL_FingerID) touchStateOld.touches[i].finger_id, window, SDL_FALSE,
-                                  (float) touchStateOld.touches[i].x / 1280.0f,
-                                  (float) touchStateOld.touches[i].y / 720.0f, 1);
+
+                if (!found) {
+                    SDL_SendTouch(id,
+                                  touchState.touches[i].finger_id,
+                                  window, SDL_TRUE,
+                                  (float)touchState.touches[i].x / rel_w,
+                                  (float)touchState.touches[i].y / rel_h, 1);
                 }
+            }
+        }
+
+        /* Scan for moves or up */
+        for (i = 0; i < touchStateOld.count; i++) {
+            found = SDL_FALSE;
+
+            for (j = 0; j < touchState.count; j++) {
+                if (touchState.touches[j].finger_id == touchStateOld.touches[i].finger_id) {
+                    found = SDL_TRUE;
+                    /* Finger moved */
+                    if (touchState.touches[j].x != touchStateOld.touches[i].x || touchState.touches[j].y != touchStateOld.touches[i].y) {
+                        SDL_SendTouchMotion(id,
+                                            (SDL_FingerID)i, window,
+                                            (float)touchState.touches[j].x / rel_w,
+                                            (float)touchState.touches[j].y / rel_h, 1);
+                    }
+                    break;
+                }
+            }
+
+            if (!found) {
+                /* Finger Up */
+                SDL_SendTouch(id,
+                              (SDL_FingerID)touchStateOld.touches[i].finger_id,
+                              window,
+                              SDL_FALSE,
+                              (float) touchStateOld.touches[i].x / rel_w,
+                              (float) touchStateOld.touches[i].y / rel_h, 1);
             }
         }
     }


### PR DESCRIPTION
THIS PULL-REQEST REPLACED BY #23
--
Audio Render is a second layer that converts the audio stream to output. Audio Out is the direct output of the audio stream without conversions.

## Description
- Added the second module SDL_switchaudioout.c which uses Audio Out instead of Audio Render
- Added SWITCHAUDIOOUT_bootstrap entry with the highest priority
- Renamed SWITCHAUDIO_bootstrap into SWITCHAUDIOREN_bootstrap
- Fixed some warnings by adding of `(void)this;` line into empty calls
- Fixed the touchscreen work:
  - The ID must be bigger than 0. If ID is 0, that means it's an invalid device, and this is confusion for such API calls as `SDL_GetTouchDevice()`
  - I rewrote the touchscreen code with a better one

## Existing Issue(s)
1) Audio Render API plays with less stability, and in some cases, may turn into silence because of overloads. Audio Out is the direct output of the audio stream without any conversions.
2) Touchscreen API worked incorrectly