### PR TITLE
[Wii] Fix joysticks' updates

### DIFF
--- a/src/joystick/wii/SDL_sysjoystick.c
+++ b/src/joystick/wii/SDL_sysjoystick.c
@@ -295,7 +295,7 @@ static void _HandleWiiJoystickUpdate(SDL_Joystick* joystick)
 	WPADData *data;
 	const u32 *buttons;
 
-	if (!WPAD_ReadPending(WPAD_CHAN_0, NULL))
+	if (!WPAD_ReadPending(joystick->index, NULL))
 		return;
 	data = WPAD_Data(joystick->index);
 	changed = data->btns_d | data->btns_u;


### PR DESCRIPTION
## Description
Because `if (!WPAD_ReadPending(WPAD_CHAN_0, NULL)) return;` was being called [in the Wiimote state update function](https://github.com/devkitPro/SDL/blob/ogc-sdl-1.2/src/joystick/wii/SDL_sysjoystick.c#L298), this caused joystick states not to update when Wiimote #0 had no pending updates. Since joysticks [are stored and updated sequentially in the order that they were opened](https://github.com/devkitPro/SDL/blob/ogc-sdl-1.2/src/joystick/SDL_joystick.c#L572), the result was that only the first Wiimote opened was being updated correctly.

The fix was very easy. Changing the line to `if (!WPAD_ReadPending(joystick->index, NULL)) return;` solved the problem.

## Existing Issue(s)
https://github.com/devkitPro/SDL/issues/19
