### PR TITLE
switch: audio: Fix deinitialization

### DIFF
--- a/src/audio/switch/SDL_switchaudio.c
+++ b/src/audio/switch/SDL_switchaudio.c
@@ -152,6 +152,7 @@ static void
 SWITCHAUDIO_CloseDevice(_THIS)
 {
     audoutStopAudioOut();
+    audoutExit();
 
     if (this->hidden->rawbuf) {
         free(this->hidden->rawbuf);


### PR DESCRIPTION
Fixes audio backend deinitialization.

## Description
The missing `audoutExit` call meant the audio backend would leak `audout` sessions upon each reinitialization. This happens typically in media players, which clean up resources after each playback.
The issue manifested in heavily artifacted/cracked audio.

## Existing Issue(s)
https://github.com/devkitPro/SDL/commit/5c844fcd97b4550babb329b6667ed76f9a64c6df#r125287796