### PR TITLE
[joystick] Fix GameCube button mapping

### DIFF
--- a/src/joystick/wii/SDL_sysjoystick.c
+++ b/src/joystick/wii/SDL_sysjoystick.c
@@ -117,17 +117,12 @@ static const u16 sdl_buttons_gc[] =
 {
 	PAD_BUTTON_A,
 	PAD_BUTTON_B,
-	0 /* 1 */,
-	0 /* 2 */,
-	0 /* - */,
-	PAD_TRIGGER_Z,
-	PAD_BUTTON_START,
-	0 /* Z */,
-	0 /* C */,
 	PAD_BUTTON_X,
 	PAD_BUTTON_Y,
 	PAD_TRIGGER_L,
-	PAD_TRIGGER_R
+	PAD_TRIGGER_R,
+	PAD_TRIGGER_Z,
+	PAD_BUTTON_START,
 };
 
 static const int __jswpad_enabled = 1;


### PR DESCRIPTION
This commit partially reverts 662e60ec9306065ddf54061db88fdaed9d795edc by removing the dummy buttons that were introduced back then: some null entries were added to the sdl_buttons_gc array, defining buttons for which no event could ever be emitted. This caused an inconsistency, where SDL_JoystickNumButtons() would claim that the joystick had 8 buttons (given that the `MAX_GC_BUTTONS` definition was not updated to account for the null entries that were added), but as a matter of fact some buttons (X, Y, L and R) could only be read by passing an index greater or equal than 8.

I've been unable to contact the original author (tueidj seems to have disappeared from the internet in 2017), but I've written to the committer, @sergiou87, who told me that he added these changes trusting the original author, but does not know the rationale behind them.

The change proposed here does not exactly revert the buttons to their original layout, but rather aims to get the button order consistent with a typical gamepad layout (including that of the Wii classic controller), where "L" comes before "R", and both come immediately after X and Y.
