### PR TITLE
[joystick] Wii: introduce split-joysticks option

### DIFF
--- a/src/joystick/ogc/SDL_sysjoystick.c
+++ b/src/joystick/ogc/SDL_sysjoystick.c
@@ -55,6 +55,8 @@
 #define AXIS_MIN	-32767  /* minimum value for axis coordinate */
 #define AXIS_MAX	32767   /* maximum value for axis coordinate */
 
+extern SDL_Joystick **SDL_joysticks;
+
 typedef struct joystick_paddata_t
 {
 	u16 prev_buttons;
@@ -119,6 +121,8 @@ static const int __numgcjoysticks = 4;
 #ifdef __wii__
 static const int __jswpad_enabled = 1;
 static const int __numwiijoysticks = 4;
+static int split_joysticks = 0;
+static int num_wii_joysticks;
 
 static const u32 sdl_buttons_wii[] =
 {
@@ -138,8 +142,46 @@ static const u32 sdl_buttons_wii[] =
 	WPAD_CLASSIC_BUTTON_ZL,
 	WPAD_CLASSIC_BUTTON_ZR
 };
+#define SDL_WII_NUM_BUTTONS_WII \
+	(sizeof(sdl_buttons_wii) / sizeof(sdl_buttons_wii[0]))
 
+static const u32 sdl_buttons_wiimote[] =
+{
+	WPAD_BUTTON_A,
+	WPAD_BUTTON_B,
+	WPAD_BUTTON_1,
+	WPAD_BUTTON_2,
+	WPAD_BUTTON_MINUS,
+	WPAD_BUTTON_PLUS,
+	WPAD_BUTTON_HOME,
+};
+#define SDL_WII_NUM_BUTTONS_WIIMOTE \
+	(sizeof(sdl_buttons_wiimote) / sizeof(sdl_buttons_wiimote[0]))
 
+static const u32 sdl_buttons_nunchuck[] =
+{
+	WPAD_NUNCHUK_BUTTON_Z,
+	WPAD_NUNCHUK_BUTTON_C,
+};
+#define SDL_WII_NUM_BUTTONS_NUNCHUCK \
+	(sizeof(sdl_buttons_nunchuck) / sizeof(sdl_buttons_nunchuck[0]))
+
+static const u32 sdl_buttons_classic[] =
+{
+	WPAD_CLASSIC_BUTTON_A,
+	WPAD_CLASSIC_BUTTON_B,
+	WPAD_CLASSIC_BUTTON_X,
+	WPAD_CLASSIC_BUTTON_Y,
+	WPAD_CLASSIC_BUTTON_FULL_L,
+	WPAD_CLASSIC_BUTTON_FULL_R,
+	WPAD_CLASSIC_BUTTON_ZL,
+	WPAD_CLASSIC_BUTTON_ZR,
+	WPAD_CLASSIC_BUTTON_MINUS,
+	WPAD_CLASSIC_BUTTON_PLUS,
+	WPAD_CLASSIC_BUTTON_HOME,
+};
+#define SDL_WII_NUM_BUTTONS_CLASSIC \
+	(sizeof(sdl_buttons_classic) / sizeof(sdl_buttons_classic[0]))
 
 /* Helpers to separate nunchuk vs classic buttons which share the
  * same scan codes. In particular, up on the classic controller is
@@ -228,29 +270,13 @@ static const u32 _buttons[8] = {
 	WPAD_CLASSIC_BUTTON_RIGHT
 };
 
-static void _HandleWiiJoystickUpdate(SDL_Joystick* joystick)
+static void HandleWiiHats(SDL_Joystick *joystick,
+                          const u32 changed, const u32 pressed,
+                          const u32 *buttons)
 {
-	u32 changed;
-	int i, axis;
-	joystick_hwdata *prev_state;
-	WPADData *data;
-	const u32 *buttons;
-
-	if (!WPAD_ReadPending(joystick->index, NULL))
-		return;
-	data = WPAD_Data(joystick->index);
-	changed = data->btns_d | data->btns_u;
-	prev_state = (joystick_hwdata*)joystick->hwdata;
-
-	if(data->exp.type == WPAD_EXP_CLASSIC) // classic controller
-		buttons = _buttons+4;
-	else
-		buttons = _buttons;
-
 	if (changed & (buttons[0]|buttons[1]|buttons[2]|buttons[3]))
 	{
 		int hat = SDL_HAT_CENTERED;
-		u32 pressed = data->btns_d | data->btns_h;
 
 		if (pressed & buttons[0]) hat |= SDL_HAT_UP;
 		if (pressed & buttons[1]) hat |= SDL_HAT_DOWN;
@@ -258,23 +284,110 @@ static void _HandleWiiJoystickUpdate(SDL_Joystick* joystick)
 		if (pressed & buttons[3]) hat |= SDL_HAT_RIGHT;
 		SDL_PrivateJoystickHat(joystick, 0, hat);
 	}
+}
 
-	for(i = 0; i < (sizeof(sdl_buttons_wii) / sizeof(sdl_buttons_wii[0])); i++)
+static void HandleWiiButtons(SDL_Joystick *joystick,
+                             const u32 changed,
+                             const WPADData *data,
+                             const u32 *buttons,
+                             size_t num_buttons)
+{
+	for (int i = 0; i < num_buttons; i++)
 	{
-		if ( (data->exp.type == WPAD_EXP_CLASSIC && wii_button_is_nunchuk(i)) ||
-				(data->exp.type == WPAD_EXP_NUNCHUK && wii_button_is_classic(i)) )
-			continue;
+		if (changed & buttons[i])
+		{
+			if (!split_joysticks &&
+				((data->exp.type == WPAD_EXP_CLASSIC && wii_button_is_nunchuk(i)) ||
+				(data->exp.type == WPAD_EXP_NUNCHUK && wii_button_is_classic(i))))
+				continue;
 
-		if (changed & sdl_buttons_wii[i])
 			SDL_PrivateJoystickButton(joystick, i,
-				(data->btns_d & sdl_buttons_wii[i]) ? SDL_PRESSED : SDL_RELEASED);
+				(data->btns_d & buttons[i]) ? SDL_PRESSED : SDL_RELEASED);
+		}
+	}
+}
+
+static void HandleWiiMotion(SDL_Joystick* joystick,
+							joystick_hwdata *prev_state,
+							WPADData *data,
+							int start_index)
+{
+	int axis = WPAD_Pitch(data);
+	if(prev_state->wiimote.wiimote_pitch != axis)
+	{
+		SDL_PrivateJoystickAxis(joystick, start_index, -(axis << 8));
+		prev_state->wiimote.wiimote_pitch = axis;
+	}
+	axis = WPAD_Roll(data);
+	if(prev_state->wiimote.wiimote_roll != axis)
+	{
+		SDL_PrivateJoystickAxis(joystick, start_index + 1, axis << 8);
+		prev_state->wiimote.wiimote_roll = axis;
+	}
+	axis = WPAD_Yaw(data);
+	if(prev_state->wiimote.wiimote_yaw != axis)
+	{
+		SDL_PrivateJoystickAxis(joystick, start_index + 2, axis << 8);
+		prev_state->wiimote.wiimote_yaw = axis;
+	}
+}
+
+static void _HandleWiiJoystickUpdate(SDL_Joystick* joystick)
+{
+	u32 changed, pressed;
+	int axis, index;
+	joystick_hwdata *prev_state;
+	WPADData *data;
+	SDL_Joystick *joy_wiimote = NULL;
+	SDL_Joystick *joy_expansion = NULL;
+
+	prev_state = (joystick_hwdata*)joystick->hwdata;
+	index = prev_state->index;
+	if (!WPAD_ReadPending(index, NULL))
+		return;
+	data = WPAD_Data(index);
+	changed = data->btns_d | data->btns_u;
+	pressed = data->btns_d | data->btns_h;
+
+	if (joystick->index >= __numwiijoysticks) {
+		/* we can get here if using the split joystick feature. But even in
+		 * that case, we don't want to do anything here: the update operation
+		 * on the wiimote must update the expansion joystick too. */
+		return;
 	}
 
-	if (data->exp.type != prev_state->wiimote.exp)
-	{
-		// Reset the expansion's axes
-		for (int i = 0; i < 6; i++)
-			SDL_PrivateJoystickAxis(joystick, i, 0);
+	if (split_joysticks) {
+		/* To find out the pointer to the linked joystick we use the knowledge
+		 * that the SDL_Joystick structures are allocated in a continuous array
+		 */
+		joy_wiimote = joystick;
+		joy_expansion = SDL_joysticks[joystick->index + 4];
+	}
+
+	if (split_joysticks) {
+		HandleWiiHats(joy_wiimote, changed, pressed, _buttons);
+		if (data->exp.type == WPAD_EXP_CLASSIC) { // classic controller
+			HandleWiiHats(joy_expansion, changed, pressed, _buttons + 4);
+		}
+	} else {
+		if (data->exp.type == WPAD_EXP_CLASSIC) // classic controller
+			HandleWiiHats(joystick, changed, pressed, _buttons + 4);
+		HandleWiiHats(joystick, changed, pressed, _buttons);
+	}
+
+	if (split_joysticks) {
+		HandleWiiButtons(joy_wiimote, changed, data,
+						 sdl_buttons_wiimote, SDL_WII_NUM_BUTTONS_WIIMOTE);
+		if (data->exp.type == WPAD_EXP_CLASSIC) {
+			HandleWiiButtons(joy_expansion, changed, data,
+							 sdl_buttons_classic, SDL_WII_NUM_BUTTONS_CLASSIC);
+		} else if (data->exp.type == WPAD_EXP_NUNCHUK) {
+			HandleWiiButtons(joy_expansion, changed, data,
+							 sdl_buttons_nunchuck, SDL_WII_NUM_BUTTONS_NUNCHUCK);
+		}
+	} else {
+		HandleWiiButtons(joystick, changed, data,
+						 sdl_buttons_wii, SDL_WII_NUM_BUTTONS_WII);
 	}
 
 	if(data->exp.type == WPAD_EXP_CLASSIC)
@@ -326,12 +439,25 @@ static void _HandleWiiJoystickUpdate(SDL_Joystick* joystick)
 			if (data->exp.classic.ljs.max.x)
 				prev_state->wiimote.classic_calibrated++;
 		}
+	}
+
+	if (data->exp.type != prev_state->wiimote.exp)
+	{
+		SDL_Joystick *joy = split_joysticks ? joy_expansion : joystick;
+		// Reset the expansion axes
+		for (int i = 0; i < 6; i++)
+			SDL_PrivateJoystickAxis(joy, i, 0);
+	}
+
+	if(data->exp.type == WPAD_EXP_CLASSIC)
+	{
+		SDL_Joystick *joy = split_joysticks ? joy_expansion : joystick;
 
 		axis = WPAD_Stick(data->exp.classic.ljs.pos.x, prev_state->wiimote.classic_cal[0][0],
 			prev_state->wiimote.classic_cal[0][1], prev_state->wiimote.classic_cal[0][2], 0);
 		if(prev_state->wiimote.classicL_stickX != axis)
 		{
-			SDL_PrivateJoystickAxis(joystick, 0, axis);
+			SDL_PrivateJoystickAxis(joy, 0, axis);
 			prev_state->wiimote.classicL_stickX = axis;
 		}
 		// y axes are reversed
@@ -339,74 +465,65 @@ static void _HandleWiiJoystickUpdate(SDL_Joystick* joystick)
 			prev_state->wiimote.classic_cal[1][1], prev_state->wiimote.classic_cal[1][2], 1);
 		if(prev_state->wiimote.classicL_stickY != axis)
 		{
-			SDL_PrivateJoystickAxis(joystick, 1, axis);
+			SDL_PrivateJoystickAxis(joy, 1, axis);
 			prev_state->wiimote.classicL_stickY = axis;
 		}
 		axis = WPAD_Stick(data->exp.classic.rjs.pos.x, prev_state->wiimote.classic_cal[2][0],
 			prev_state->wiimote.classic_cal[2][1], prev_state->wiimote.classic_cal[2][2], 0);
 		if(prev_state->wiimote.classicR_stickX != axis)
 		{
-			SDL_PrivateJoystickAxis(joystick, 2, axis);
+			SDL_PrivateJoystickAxis(joy, 2, axis);
 			prev_state->wiimote.classicR_stickX = axis;
 		}
 		axis = WPAD_Stick(data->exp.classic.rjs.pos.y, prev_state->wiimote.classic_cal[3][0],
 			prev_state->wiimote.classic_cal[3][1], prev_state->wiimote.classic_cal[3][2], 1);
 		if(prev_state->wiimote.classicR_stickY != axis)
 		{
-			SDL_PrivateJoystickAxis(joystick, 3, axis);
+			SDL_PrivateJoystickAxis(joy, 3, axis);
 			prev_state->wiimote.classicR_stickY = axis;
 		}
 		axis = data->exp.classic.r_shoulder;
 		if(prev_state->wiimote.classic_triggerR != axis)
 		{
-			SDL_PrivateJoystickAxis(joystick, 4, axis<<8);
+			SDL_PrivateJoystickAxis(joy, 4, axis<<8);
 			prev_state->wiimote.classic_triggerR = axis;
 		}
 		axis = data->exp.classic.l_shoulder;
 		if(prev_state->wiimote.classic_triggerL != axis)
 		{
-			SDL_PrivateJoystickAxis(joystick, 5, axis<<8);
+			SDL_PrivateJoystickAxis(joy, 5, axis<<8);
 			prev_state->wiimote.classic_triggerL = axis;
 		}
 	}
 	else if(data->exp.type == WPAD_EXP_NUNCHUK)
 	{
+		SDL_Joystick *joy = split_joysticks ? joy_expansion : joystick;
+
 		axis = WPAD_Stick(data->exp.nunchuk.js.pos.x, data->exp.nunchuk.js.min.x,
 			data->exp.nunchuk.js.center.x, data->exp.nunchuk.js.max.x, 0);
 		if(prev_state->wiimote.nunchuk_stickX != axis)
 		{
-			SDL_PrivateJoystickAxis(joystick, 0, axis);
+			SDL_PrivateJoystickAxis(joy, 0, axis);
 			prev_state->wiimote.nunchuk_stickX = axis;
 		}
 		axis = WPAD_Stick(data->exp.nunchuk.js.pos.y, data->exp.nunchuk.js.min.y,
 			data->exp.nunchuk.js.center.y, data->exp.nunchuk.js.max.y, 1);
 		if(prev_state->wiimote.nunchuk_stickY != axis)
 		{
-			SDL_PrivateJoystickAxis(joystick, 1, axis);
+			SDL_PrivateJoystickAxis(joy, 1, axis);
 			prev_state->wiimote.nunchuk_stickY = axis;
 		}
 	}
 
 	prev_state->wiimote.exp = data->exp.type;
 
-	axis = WPAD_Pitch(data);
-	if(prev_state->wiimote.wiimote_pitch != axis)
-	{
-		SDL_PrivateJoystickAxis(joystick, 6, -(axis << 8));
-		prev_state->wiimote.wiimote_pitch = axis;
+	if (split_joysticks) {
+		// also update the expansion
+		((joystick_hwdata*)joy_expansion->hwdata)->wiimote.exp = data->exp.type;
 	}
-	axis = WPAD_Roll(data);
-	if(prev_state->wiimote.wiimote_roll != axis)
-	{
-		SDL_PrivateJoystickAxis(joystick, 7, axis << 8);
-		prev_state->wiimote.wiimote_roll = axis;
-	}
-	axis = WPAD_Yaw(data);
-	if(prev_state->wiimote.wiimote_yaw != axis)
-	{
-		SDL_PrivateJoystickAxis(joystick, 8, axis << 8);
-		prev_state->wiimote.wiimote_yaw = axis;
-	}
+
+	int start_index = split_joysticks ? 0 : 6;
+	HandleWiiMotion(split_joysticks ? joy_wiimote : joystick, prev_state, data, start_index);
 }
 
 #endif
@@ -418,19 +535,62 @@ static void _HandleWiiJoystickUpdate(SDL_Joystick* joystick)
  */
 int SDL_SYS_JoystickInit(void)
 {
+#ifdef __wii__
+	const char *split_joystick_env = getenv("SDL_WII_JOYSTICK_SPLIT");
+	split_joysticks = split_joystick_env && strcmp(split_joystick_env, "1") == 0;
+	/* Multiply by two because each wiimote might have an expansion connected */
+	num_wii_joysticks = split_joysticks ? __numwiijoysticks * 2 : __numwiijoysticks;
+	return num_wii_joysticks + __numgcjoysticks;
+#else
 	return MAX_JOYSTICKS;
+#endif
 }
 
-static char joy_name[20] = "Gamecube 0";
+static char joy_name[64] = "Gamecube 0";
 
 /* Function to get the device-dependent name of a joystick */
 const char *SDL_SYS_JoystickName(int index)
 {
 	if(index>=0) {
 #ifdef __wii__
-		if((index < 4) && (__jswpad_enabled) && (index < __numwiijoysticks))
-			sprintf(joy_name, "Wiimote %d", index);
-		else if((index < 8) && (__jspad_enabled) && (index < (__numgcjoysticks + 4)) && (index> 3))
+		if((__jswpad_enabled) && (index < num_wii_joysticks)) {
+			joystick_hwdata *hwdata = (joystick_hwdata*)SDL_joysticks[index]->hwdata;
+			char *name_ptr = joy_name;
+			if (index < __numwiijoysticks) {
+				name_ptr += sprintf(name_ptr, "Wiimote %d", index);
+				if (!split_joysticks) {
+				    // Add expansion information
+					switch (hwdata->wiimote.exp) {
+					case WPAD_EXP_NUNCHUK:
+						strcpy(name_ptr, " + Nunchuk"); break;
+					case WPAD_EXP_CLASSIC:
+						strcpy(name_ptr, " + Classic"); break;
+					case WPAD_EXP_GUITARHERO3:
+						strcpy(name_ptr, " + Guitar Hero 3"); break;
+					case WPAD_EXP_WIIBOARD:
+						strcpy(name_ptr, " + Balance board"); break;
+					}
+				}
+			} else {
+				/* This is an expansion and we are using the split controllers
+				 * option: show only the expansion name, then. */
+				int idx = index - __numwiijoysticks;
+				switch (hwdata->wiimote.exp) {
+				case WPAD_EXP_NUNCHUK:
+					sprintf(name_ptr, "Nunchuk %d", idx); break;
+				case WPAD_EXP_CLASSIC:
+					sprintf(name_ptr, "Classic %d", idx); break;
+				case WPAD_EXP_GUITARHERO3:
+					sprintf(name_ptr, "Guitar Hero 3 %d", idx); break;
+				case WPAD_EXP_WIIBOARD:
+					sprintf(name_ptr, "Balance board %d", idx); break;
+				case WPAD_EXP_NONE:
+					strcpy(name_ptr, "Disconnected"); break;
+				default:
+					sprintf(name_ptr, "Unknown %d", idx); break;
+				}
+			}
+		} else if((__jspad_enabled) && (index < (num_wii_joysticks + __numgcjoysticks)))
 #endif
 			sprintf(joy_name, "Gamecube %d", index);
 	}
@@ -453,27 +613,37 @@ int SDL_SYS_JoystickOpen(SDL_Joystick *joystick)
 	}
 	SDL_memset(joystick->hwdata, 0, sizeof(joystick_hwdata));
 #ifdef __wii__
-	if((joystick->index < 4) && (__jswpad_enabled))
+	if((joystick->index < num_wii_joysticks) && (__jswpad_enabled))
 	{
-		if(joystick->index < __numwiijoysticks)
-		{
-			((joystick_hwdata*)(joystick->hwdata))->index = joystick->index;
-			((joystick_hwdata*)(joystick->hwdata))->type = 0;
+		int index = (joystick->index > __numwiijoysticks) ? (joystick->index - __numwiijoysticks) : joystick->index;
+		((joystick_hwdata*)(joystick->hwdata))->index = index;
+		((joystick_hwdata*)(joystick->hwdata))->type = 0;
+		if (split_joysticks) {
+			if (joystick->index < __numwiijoysticks) {
+				// wiimote
+				joystick->nbuttons = SDL_WII_NUM_BUTTONS_WIIMOTE;
+				joystick->naxes = 3;
+				joystick->nhats = 1;
+			} else {
+				// expansion
+				joystick->nbuttons = SDL_max(SDL_WII_NUM_BUTTONS_NUNCHUCK,
+				                             SDL_WII_NUM_BUTTONS_CLASSIC);
+				joystick->naxes = 6;
+				joystick->nhats = 1;
+			}
+		} else {
 			joystick->nbuttons = MAX_WII_BUTTONS;
 			joystick->naxes = MAX_WII_AXES;
 			joystick->nhats = MAX_WII_HATS;
 		}
 	}
-	else if((joystick->index < 8) && (__jspad_enabled))
+	else if((joystick->index < num_wii_joysticks + __numgcjoysticks) && (__jspad_enabled))
 	{
-		if(joystick->index < (__numgcjoysticks + 4))
-		{
-			((joystick_hwdata*)(joystick->hwdata))->index = joystick->index - 4;
-			((joystick_hwdata*)(joystick->hwdata))->type = 1;
-			joystick->nbuttons = MAX_GC_BUTTONS;
-			joystick->naxes = MAX_GC_AXES;
-			joystick->nhats = MAX_GC_HATS;
-		}
+		((joystick_hwdata*)(joystick->hwdata))->index = joystick->index - num_wii_joysticks;
+		((joystick_hwdata*)(joystick->hwdata))->type = 1;
+		joystick->nbuttons = MAX_GC_BUTTONS;
+		joystick->naxes = MAX_GC_AXES;
+		joystick->nhats = MAX_GC_HATS;
 	}
 #else
 	if((joystick->index < 4) && (__jspad_enabled))
@@ -498,7 +668,7 @@ static void _HandleGCJoystickUpdate(SDL_Joystick* joystick)
 	int i;
 	int axis;
 	joystick_hwdata *prev_state;
-	int index = joystick->index - 4;
+	int index = joystick->index - num_wii_joysticks;
 
 	buttons = PAD_ButtonsHeld(index);
 	prev_state = (joystick_hwdata *)joystick->hwdata;
@@ -582,8 +752,14 @@ void SDL_SYS_JoystickUpdate(SDL_Joystick *joystick)
 	{
 #ifdef __wii__
 		case 0:
-			if(__jswpad_enabled)
+			if(__jswpad_enabled) {
+				if (split_joysticks && joystick->index >= __numwiijoysticks) {
+					/* the actual joystick we want to update is always the wiimote
+					 * one */
+					joystick = SDL_joysticks[joystick->index - __numwiijoysticks];
+				}
 				_HandleWiiJoystickUpdate(joystick);
+            }
 			break;
 #endif
 		case 1:


### PR DESCRIPTION
Add an option to present the Wii controller expansions as independent controllers.

Introduce the SDL_WII_JOYSTICK_SPLIT environment variable, which, if set to "1" before initializing the joystick subsystem, changes the number of reported joysticks from 8 to 12:

- Joysticks 0-3: the 4 wiimotes
- Joysticks 4-7: the 4 expansions
- Joysticks 8-11: the 4 GameCube controllers

This is for the benefits of those applications which need to alter their behaviour depending on the controller that generated the event, or even to increase the number of possible players in a game, assuming that it needs just the directional keys and a couple of buttons.

Due to the refactoring, some changes were made to the default non-split view of the controllers, a couple of which are actually bugfixes:

- When a classic controller is being used, the arrow keys (hat) on the wiimote also work, delivering the same events as the arrow keys on the classic controller (previously, pressing them would produce no effect whatsoever, which looks like a bug).

- When an expansion is detached, its axes are reset to 0; previously, they would continue to be reported as moving, therefore rendering the controller unusable.

- Naming of the Wii controllers has been extended and now looks as following (assuming that we are operating on the second wiimote), depending on the expansion attached:
  * `Wiimote 1` (if no expansion is attached)
  * `Wiimote 1 + Nunchuck`
  * `Wiimote 1 + Classic`
  * `Wiimote 1 + Guitar Hero 3`
  * `Wiimote 1 + Balance board`
  
  This can help applications to map buttons and axes to their proper function.

All these changes can be easily tested with [this application](https://github.com/mardy/sdl-controller-text); both modes of operation can be tested, just by commenting out the

    setenv("SDL_WII_JOYSTICK_SPLIT", "1", 1);

line in the `init()` function, if you want to check the non-split functionality. The application can also be built against the devkitPro version of the SDL, for a comparison. Please let me know if you'd like the binary DOL file for quicker testing.

