### PR TITLE
[OGC] Fix priority of threads

### DIFF
--- a/src/joystick/wii/SDL_sysjoystick.c
+++ b/src/joystick/wii/SDL_sysjoystick.c
@@ -295,7 +295,7 @@ static void _HandleWiiJoystickUpdate(SDL_Joystick* joystick)
 	WPADData *data;
 	const u32 *buttons;
 
-	if (!WPAD_ReadPending(WPAD_CHAN_0, NULL))
+	if (!WPAD_ReadPending(joystick->index, NULL))
 		return;
 	data = WPAD_Data(joystick->index);
 	changed = data->btns_d | data->btns_u;

--- a/src/thread/ogc/SDL_systhread.c
+++ b/src/thread/ogc/SDL_systhread.c
@@ -49,7 +49,7 @@ void *run_thread(void *data)
 int SDL_SYS_CreateThread(SDL_Thread *thread, void *args)
 {
 	
-	if ( LWP_CreateThread(&thread->handle, run_thread, args, 0, 0, 64) != 0 ) {
+	if ( LWP_CreateThread(&thread->handle, run_thread, args, 0, 0, 63) != 0 ) {
 		SDL_SetError("Not enough resources to create thread");
 		return(-1);
 	}


### PR DESCRIPTION
## Description
`SDL_CreateThread()` calls `SDL_SYS_CreateThread()`, which in turn just calls `LWP_CreateThread(&thread->handle, run_thread, args, 0, 0, 64)`, with 64 being the priority of the thread. It appears that 64 is also the priority of the main thread in libOGC. I don't know how the thread scheduler works (some insight would be appreciated), but the tie's effect is that spawned threads never yield back control of the CPU to the main thread until they finish. Lowering the priority of the new threads by 1 seems to restore concurrency, but maybe a different value would be more suitable.
