### PR TITLE
ogc: fix wrong values reported on GameCube controller triggers

### DIFF
--- a/src/joystick/ogc/SDL_sysjoystick.c
+++ b/src/joystick/ogc/SDL_sysjoystick.c
@@ -553,14 +553,14 @@ static void _HandleGCJoystickUpdate(SDL_Joystick* joystick)
 	axis = PAD_TriggerL(index);
 	if(prev_state->gamecube.triggerL != axis)
 	{
-		SDL_PrivateJoystickAxis(joystick, 4, axis << 8);
+		SDL_PrivateJoystickAxis(joystick, 4, axis << 7);
 		prev_state->gamecube.triggerL = axis;
 	}
 
 	axis = PAD_TriggerR(index);
 	if(prev_state->gamecube.triggerR != axis)
 	{
-		SDL_PrivateJoystickAxis(joystick, 5, axis << 8);
+		SDL_PrivateJoystickAxis(joystick, 5, axis << 7);
 		prev_state->gamecube.triggerR = axis;
 	}
 }


### PR DESCRIPTION
These two axes values are unsigned, and all 8 bits can be used; therefore, in order to reach SHRT_MAX we only need to shift them by 7 bits, not 8. This avoids having the value wrap down to zero midway.
