### PR TITLE
ogc: rework audio driver to avoid clicks and gaps

### DIFF
--- a/src/audio/ogc/SDL_ogcaudio.h
+++ b/src/audio/ogc/SDL_ogcaudio.h
@@ -25,13 +25,13 @@
 #include <aesndlib.h>
 #include <ogcsys.h>
 
-#include <ogc/cond.h>
 #include <ogc/mutex.h>
+#include <ogc/semaphore.h>
 
 /* Hidden "this" pointer for the audio functions */
 #define _THIS SDL_AudioDevice *this
 
-#define NUM_BUFFERS            2 /* -- Minimum 2! */
+#define NUM_BUFFERS            4 /* -- Minimum 2! */
 #define SAMPLES_PER_DMA_BUFFER (DSP_STREAMBUFFER_SIZE)
 #define DMA_BUFFER_SIZE        (SAMPLES_PER_DMA_BUFFER * 2 * sizeof(short))
 
@@ -44,9 +44,10 @@ struct SDL_PrivateAudioData
     /* Speaker data */
     Uint32 format;
     Uint8 bytes_per_sample;
-    Uint32 nextbuf;
+    s8 nextbuf;
+    s8 playing_buffer;
     mutex_t lock;
-    cond_t cv;
+    sem_t available_buffers;
 };
 
 #endif /* _SDL_ogcaudio_h_ */


### PR DESCRIPTION
When playing an audio stream the previous implementation was producing frequent clicks (also audible in the emulator). The reason is that SDL runs a thread that does these operations in a loop:

1. Ask the driver for a buffer (GetDeviceBuf())
2. Fill the buffer with audio data from the app
3. Call PlayAudio() on the driver
4. Call WaitDevice() on the driver

The clicks occurred because after a buffer had finished playing, our completion callback would set the condition variable, allowing the audio thread (which was blocking in point 4) to continue. However, since libaesnd does not offer an API to queue audio buffer, we were sending the next audio buffer only in PlayAudio(), that is after the points 1 and 2 were performed. And since point 2 involves copying buffers and possibly even converting them, this would often generate an audible delay.

The solution is to play the next buffer directly from the completion callback. The waiting logic has been rewritten to use a semaphore blocking on the availability of a buffer for writing (not for playback!).

The number of buffers has also been increase to protect against sudden spikes in CPU usage, although in the test applications 2 buffers are good enough too.
