### PR TITLE
ogc: do not create a new mouse cursor at every frame

### DIFF
--- a/src/video/ogc/SDL_ogcevents.c
+++ b/src/video/ogc/SDL_ogcevents.c
@@ -49,7 +49,7 @@ static const struct {
 
 static void pump_ir_events(_THIS)
 {
-    SDL_Cursor *cursor;
+    SDL_Mouse *mouse = SDL_GetMouse();
     bool wiimote_pointed_at_screen = false;
 
     if (!_this->windows) return;
@@ -89,9 +89,10 @@ static void pump_ir_events(_THIS)
      * is hidden. Note that this only affects applications which haven't
      * explicitly set a cursor: the others remain in full control of whether a
      * cursor should be shown or not. */
-    cursor = wiimote_pointed_at_screen ?
-        OGC_CreateSystemCursor(SDL_SYSTEM_CURSOR_HAND) : NULL;
-    SDL_SetDefaultCursor(cursor);
+    if (mouse && mouse->cur_cursor == mouse->def_cursor &&
+        mouse->cursor_shown != wiimote_pointed_at_screen) {
+        SDL_ShowCursor(wiimote_pointed_at_screen);
+    }
 }
 #endif
 

--- a/src/video/ogc/SDL_ogcmouse.c
+++ b/src/video/ogc/SDL_ogcmouse.c
@@ -160,6 +160,8 @@ void OGC_InitMouse(_THIS)
     mouse->CreateCursor = OGC_CreateCursor;
     mouse->CreateSystemCursor = OGC_CreateSystemCursor;
     mouse->FreeCursor = OGC_FreeCursor;
+
+    SDL_SetDefaultCursor(OGC_CreateSystemCursor(SDL_SYSTEM_CURSOR_HAND));
 }
 
 void OGC_QuitMouse(_THIS)


### PR DESCRIPTION
The system default cursor is not supposed to change, so we can create it just once (when the mouse gets initialized). In the polling callback we then just need to hide or show it.

The logic of showing is not changed: if the application has set a specific cursor, then it's in full control of its visibility; but if it's using the default cursor, then we show the cursor only if at least one wiimote is pointed at the screen.
