### PR TITLE
ogc: apply viewport scale in QueueGeometry

### DIFF
--- a/src/render/ogc/SDL_render_ogc.c
+++ b/src/render/ogc/SDL_render_ogc.c
@@ -302,8 +302,8 @@ static int OGC_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL
         vertex = vertices + size_per_element * i;
 
         vertex_xy = (SDL_FPoint *)vertex;
-        vertex_xy->x = xy_[0];
-        vertex_xy->y = xy_[1];
+        vertex_xy->x = xy_[0] * scale_x;
+        vertex_xy->y = xy_[1] * scale_x;
 
         *(SDL_Color *)(vertex + sizeof(SDL_FPoint)) = col;
 


### PR DESCRIPTION
The `scale_x` and `scale_y` parameters to QueueGeometry need to be applied to the geometry coordinates. Without this, the SDL_RenderSetLogicalSize() would not properly work on the renderer.

Note that a similar scale does not need to be applied by the backend in the other draw functions (line, fill, copyrect), because the coordinates are already scaled then.
