### PR TITLE
ogc: always give focus to the window

### DIFF
--- a/src/video/ogc/SDL_ogcvideo.c
+++ b/src/video/ogc/SDL_ogcvideo.c
@@ -47,6 +47,12 @@
 static int OGC_VideoInit(_THIS);
 static void OGC_VideoQuit(_THIS);
 
+static void OGC_ShowWindow(_THIS, SDL_Window *window)
+{
+    SDL_SetMouseFocus(window);
+    SDL_SetKeyboardFocus(window);
+}
+
 /* OGC driver bootstrap functions */
 
 static void OGC_DeleteDevice(SDL_VideoDevice *device)
@@ -80,6 +86,7 @@ static SDL_VideoDevice *OGC_CreateDevice(void)
     device->VideoInit = OGC_VideoInit;
     device->VideoQuit = OGC_VideoQuit;
     device->PumpEvents = OGC_PumpEvents;
+    device->ShowWindow = OGC_ShowWindow;
     device->CreateWindowFramebuffer = SDL_OGC_CreateWindowFramebuffer;
     device->UpdateWindowFramebuffer = SDL_OGC_UpdateWindowFramebuffer;
     device->DestroyWindowFramebuffer = SDL_OGC_DestroyWindowFramebuffer;


### PR DESCRIPTION
We support only one window and that should receive the focus. Failing to do this breaks the delivering of Joystick and GameController events, unless the SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS hints is set (which is not, by default).

Some backends do this in CreateWindow(), some in ShowWindow(). In our case it doesn't really make a difference, but ShowWindow() sounds more correct.
