### PR TITLE
ogc: set fullscreen height to EFB's height

### DIFF
--- a/src/video/ogc/SDL_ogcvideo.c
+++ b/src/video/ogc/SDL_ogcvideo.c
@@ -153,7 +153,7 @@ int OGC_VideoInit(_THIS)
     SDL_zero(mode);
     mode.format = SDL_PIXELFORMAT_ARGB8888;
     mode.w = vmode->fbWidth;
-    mode.h = vmode->xfbHeight;
+    mode.h = vmode->efbHeight;
     mode.refresh_rate = 60;
     mode.driverdata = NULL;
     if (SDL_AddBasicVideoDisplay(&mode) < 0) {


### PR DESCRIPTION
Since rendering happens on the EFB, we should report its height as the fullscreen display's height. Failing to do so results in missing part of the picture and/or in invalid memory accesses.
