### PR TITLE
ogc: Do't use 0x0000 as a product ID for the joysticks

### DIFF
--- a/src/joystick/ogc/SDL_sysjoystick.c
+++ b/src/joystick/ogc/SDL_sysjoystick.c
@@ -496,7 +496,7 @@ static SDL_JoystickGUID OGC_JoystickGetDeviceGUID(int device_index)
      * Since we want the gamepads to appear with the numeric ID in their
      * name, we make them unique by assigning a different product depending on
      * the port. */
-    product = index << 8;
+    product = (index + 1) << 8;
     if (index >= GC_JOYSTICKS_START && index < GC_JOYSTICKS_END) {
         bus = SDL_HARDWARE_BUS_UNKNOWN;
     } else {


### PR DESCRIPTION
With the previous logic, the first GameCube controller was given the product ID 0x0000, which might be used as a special value in some applications.

With this change the first GameCube controller is given the product ID 0x0100.
