### PR TITLE
Fix GameController interface on Switch

### DIFF
--- a/src/joystick/SDL_gamecontrollerdb.h
+++ b/src/joystick/SDL_gamecontrollerdb.h
@@ -993,7 +993,7 @@ static const char *s_ControllerMappings[] = {
     "000000004e696e74656e646f20334400,Nintendo 3DS,crc:3210,a:b0,b:b1,back:b2,dpdown:b7,dpleft:b5,dpright:b4,dpup:b6,leftshoulder:b9,lefttrigger:b14,leftx:a0,lefty:a1,rightshoulder:b8,righttrigger:b15,rightx:a2,righty:a3,start:b3,x:b10,y:b11,",
 #endif
 #if defined(SDL_JOYSTICK_SWITCH)
-    "53776974636820436F6E74726F6C6C65,Switch Controller,a:b1,b:b0,back:b11,dpdown:b15,dpleft:b12,dpright:b14,dpup:b13,leftshoulder:b6,leftstick:b4,lefttrigger:b8,leftx:a0,lefty:a1,rightshoulder:b7,rightstick:b5,righttrigger:b9,rightx:a2,righty:a3,start:b10,x:b3,y:b2,",
+    "000038f853776974636820436f6e7400,Switch Controller,a:b1,b:b0,back:b11,dpdown:b15,dpleft:b12,dpright:b14,dpup:b13,leftshoulder:b6,leftstick:b4,lefttrigger:b8,leftx:a0,lefty:a1,rightshoulder:b7,rightstick:b5,righttrigger:b9,rightx:a2,righty:a3,start:b10,x:b3,y:b2,",
 #endif
     "hidapi,*,a:b0,b:b1,back:b4,dpdown:b12,dpleft:b13,dpright:b14,dpup:b11,guide:b5,leftshoulder:b9,leftstick:b7,lefttrigger:a4,leftx:a0,lefty:a1,rightshoulder:b10,rightstick:b8,righttrigger:a5,rightx:a2,righty:a3,start:b6,x:b2,y:b3,",
     NULL

--- a/src/joystick/switch/SDL_sysjoystick.c
+++ b/src/joystick/switch/SDL_sysjoystick.c
@@ -201,12 +201,9 @@ static void SWITCH_JoystickSetDevicePlayerIndex(int device_index, int player_ind
 }
 
 static SDL_JoystickGUID SWITCH_JoystickGetDeviceGUID(int device_index) {
-    SDL_JoystickGUID guid;
-    /* the GUID is just the first 16 chars of the name for now */
+    /* the GUID is just the name for now */
     const char *name = SWITCH_JoystickGetDeviceName(device_index);
-    SDL_zero(guid);
-    SDL_memcpy(&guid, name, SDL_min(sizeof(guid), SDL_strlen(name)));
-    return guid;
+    return SDL_CreateJoystickGUIDForName(name);
 }
 
 /* Function to perform the mapping from device index to the instance id for this index */


### PR DESCRIPTION
This fixes Switch controllers not being recognized as SDL_GameControllers because of missing mappings.

The GUID struct was changed at some point in recent SDL2.

The GUID is not simply the first 16 characters of the joystick name anymore as it used to be. The first four bytes now contain a number related to the hardware bus and a crc16 of the name, see here: https://github.com/devkitPro/SDL/blob/ed13eea0aaca1caed8d2052a4db8ebb0b4a0f302/src/joystick/SDL_joystick.c#L2111 To be correct, the GUID must be constructed from the joystick name via the function SDL_CreateJoystickGUIDForName(). Compare this also to upstreamed platforms like Vita and PS2 where that function is now also used. I then checked the resulting GUID string via SDL_JoystickGetGUIDString(), and used it to fix the mapping line.

Tested with DevilutionX, where controls now work again. 
