### PR TITLE
Fix regression with stuttery audio after suspend

### DIFF
--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -112,7 +112,7 @@ static const AudioBootStrap *const bootstrap[] = {
     &EMSCRIPTENAUDIO_bootstrap,
 #endif
 #if SDL_AUDIO_DRIVER_SWITCH
-    &SWITCHAUDIOOUT_bootstrap,
+    &SWITCHAUDIO_bootstrap,
 #endif
 #if SDL_AUDIO_DRIVER_JACK
     &JACK_bootstrap,

--- a/src/audio/SDL_sysaudio.h
+++ b/src/audio/SDL_sysaudio.h
@@ -209,7 +209,7 @@ extern AudioBootStrap VITAAUD_bootstrap;
 extern AudioBootStrap N3DSAUDIO_bootstrap;
 extern AudioBootStrap EMSCRIPTENAUDIO_bootstrap;
 extern AudioBootStrap OS2AUDIO_bootstrap;
-extern AudioBootStrap SWITCHAUDIOOUT_bootstrap;
+extern AudioBootStrap SWITCHAUDIO_bootstrap;
 
 #endif /* SDL_sysaudio_h_ */
 

--- a/src/audio/switch/SDL_switchaudio.c
+++ b/src/audio/switch/SDL_switchaudio.c
@@ -152,7 +152,6 @@ static void
 SWITCHAUDIO_CloseDevice(_THIS)
 {
     audoutStopAudioOut();
-    audoutExit();
 
     if (this->hidden->rawbuf) {
         free(this->hidden->rawbuf);

--- a/src/audio/switch/SDL_switchaudio.h
+++ b/src/audio/switch/SDL_switchaudio.h
@@ -28,21 +28,14 @@
 /* Hidden "this" pointer for the audio functions */
 #define _THIS   SDL_AudioDevice *this
 
-#define NUM_BUFFERS 2
-
 struct SDL_PrivateAudioData
 {
-    AudioOutBuffer buffer[NUM_BUFFERS];
-    AudioOutBuffer *released_out_buffer;
-    u32 released_out_count;
-    /* The raw allocated mixing buffer. */
-    Uint8   *rawbuf;
-    /* Individual mixing buffers. */
-    void *out_buffers[NUM_BUFFERS];
-    /* Index of the next available mixing buffer. */
-    int     next_buffer;
-    /* Currently playing buffer */
-    int     cur_buffer;
+    AudioDriver driver;
+    AudioDriverWaveBuf buffer[2];
+    void *buffer_tmp;
+    void *pool;
+    bool audr_device;
+    bool audr_driver;
 };
 
 #endif /* SDL_switchaudio_h_ */


### PR DESCRIPTION
The switch from audren back to audout caused a regression where audio is scratchy/stuttery after suspend, i.e. when the Switch is put to sleep and woken up while homebrew is playing audio.

This was a longstanding issue and one of the reasons why cpasjuste switched from audout to audren years ago.

Unless there are compelling issues to use audout instead of audren, and the scratchy audio on wake from suspend can be fixed, we should stick with audren.

## Description
Reverted the commits that switched from audren back to audout.

## Existing Issue(s)
None.