### PR TITLE
Add more video modes

### DIFF
--- a/src/video/ogc/SDL_ogcevents.c
+++ b/src/video/ogc/SDL_ogcevents.c
@@ -49,6 +49,8 @@ static const struct {
 
 static void pump_ir_events(_THIS)
 {
+    int screen_w, screen_h;
+
     if (!_this->windows) return;
 
     if (!SDL_WasInit(SDL_INIT_JOYSTICK)) {
@@ -58,13 +60,17 @@ static void pump_ir_events(_THIS)
         WPAD_ReadPending(WPAD_CHAN_ALL, NULL);
     }
 
+    screen_w = _this->displays[0].current_mode.w;
+    screen_h = _this->displays[0].current_mode.h;
+
     for (int i = 0; i < 4; i++) {
         WPADData *data = WPAD_Data(i);
 
         if (!data->ir.valid) continue;
 
-        SDL_SendMouseMotion(_this->windows, i,
-                            0, data->ir.x, data->ir.y);
+        SDL_SendMouseMotion(_this->windows, i, 0,
+                            data->ir.x * screen_w / 640,
+                            data->ir.y * screen_h / 480);
 
         for (int b = 0; b < MAX_WII_MOUSE_BUTTONS; b++) {
             if (data->btns_d & s_mouse_button_map[b].wii) {

--- a/src/video/ogc/SDL_ogcvideo.c
+++ b/src/video/ogc/SDL_ogcvideo.c
@@ -46,6 +46,9 @@
 // Inverse of the VI_TVMODE macro
 #define VI_FORMAT_FROM_MODE(tvmode) (tvmode >> 2)
 
+/* A video mode with a 320 width; we'll build it programmatically. */
+static GXRModeObj s_mode320;
+
 static const GXRModeObj *s_ntsc_modes[] = {
     &TVNtsc240Ds,
     &TVNtsc480Prog,
@@ -127,6 +130,19 @@ static void add_supported_modes(SDL_VideoDisplay *display, u32 tv_format)
         return;
     }
 
+    /* All libogc video modes are 640 pixel wide, even the 240p ones. While
+     * this can be useful for some applications, others might prefer a video
+     * mode with less elongated pixels, such as 320x240. Therefore, let's
+     * create one: we take the first video mode in the array (which has always
+     * a height of approximately 240p) and we use it as template to build the
+     * "mode320": we just set the fbWidth field to 320: the VI interface will
+     * take care of the horizontal scale for us. */
+    memcpy(&s_mode320, gx_modes[0], sizeof(s_mode320));
+    s_mode320.fbWidth = 320;
+    init_display_mode(&mode, &s_mode320);
+    SDL_AddDisplayMode(display, &mode);
+
+    /* Now add all the "standard" modes from libogc */
     while (*gx_modes) {
         init_display_mode(&mode, *gx_modes);
         SDL_AddDisplayMode(display, &mode);


### PR DESCRIPTION
Add support for video mode switching. There are apps that might benefit from lower resolution video modes, so let's expose them.

It's recommended to review this PR commit by commit.

This has been tested with the [oceanpop](https://sharkwouter.github.io/oceanpop/) game, which has an option to enumerate the video modes and switch between them. A build is available here: https://github.com/mardy/oceanpop/releases/tag/1.1-20240324