### PR TITLE
Rotate cursor

### DIFF
--- a/src/video/ogc/SDL_ogcmouse.c
+++ b/src/video/ogc/SDL_ogcmouse.c
@@ -35,6 +35,7 @@
 #include <malloc.h>
 #include <ogc/cache.h>
 #include <ogc/gx.h>
+#include <wiiuse/wpad.h>
 
 typedef struct _OGC_CursorData
 {
@@ -189,6 +190,16 @@ void OGC_draw_cursor(_THIS)
 
     guMtxIdentity(mv);
     guMtxScaleApply(mv, mv, screen_w / 640.0f, screen_h / 480.0f, 1.0f);
+    /* If this is the default cursor, rotate it too */
+    if (mouse->cur_cursor == mouse->def_cursor) {
+        Mtx rot;
+        float angle;
+        WPADData *data = WPAD_Data(mouse->mouseID);
+
+        angle = data->ir.angle;
+        guMtxRotDeg(rot, 'z', angle);
+        guMtxConcat(mv, rot, mv);
+    }
     guMtxTransApply(mv, mv, mouse->x, mouse->y, 0);
     GX_LoadPosMtxImm(mv, GX_PNMTX1);
 


### PR DESCRIPTION
NOTE: this PR depends on https://github.com/devkitPro/SDL/pull/65, so it should be merged after it. It consists of the last commit only.

ogc: rotate mouse cursor to match wiimote orientation
   
Set a rotation on the mouse cursor to match the wiimote angle. Note that
we do this only with the default hand-shaped cursor: if the application
has set a different cursor, we should not rotate it.
    
Fixes: #63
