### PR TITLE
Render to tex improvements

### DIFF
--- a/src/render/ogc/SDL_render_ogc.c
+++ b/src/render/ogc/SDL_render_ogc.c
@@ -533,6 +533,7 @@ static int OGC_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd, v
         cmd = cmd->next;
     }
 
+    GX_DrawDone();
     return 0;
 }
 

--- a/src/render/ogc/SDL_render_ogc.c
+++ b/src/render/ogc/SDL_render_ogc.c
@@ -149,6 +149,7 @@ static void save_efb_to_texture(SDL_Texture *texture)
     GX_SetTexCopySrc(0, 0, texture->w, texture->h);
     GX_SetTexCopyDst(texture->w, texture->h, ogc_tex->format, GX_FALSE);
     GX_CopyTex(ogc_tex->texels, GX_TRUE);
+    GX_PixModeSync();
 }
 
 static void update_texture(SDL_Texture *texture, const SDL_Rect *rect,

--- a/src/render/ogc/SDL_render_ogc.c
+++ b/src/render/ogc/SDL_render_ogc.c
@@ -140,6 +140,11 @@ static void load_efb_from_texture(SDL_Renderer *renderer, SDL_Texture *texture)
 static void save_efb_to_texture(SDL_Texture *texture)
 {
     OGC_TextureData *ogc_tex = texture->driverdata;
+    u32 texture_size;
+
+    texture_size = GX_GetTexBufferSize(texture->w, texture->h, ogc_tex->format,
+                                       GX_FALSE, 0);
+    DCInvalidateRange(ogc_tex->texels, texture_size);
 
     GX_SetTexCopySrc(0, 0, texture->w, texture->h);
     GX_SetTexCopyDst(texture->w, texture->h, ogc_tex->format, GX_FALSE);

--- a/src/render/ogc/SDL_render_ogc.c
+++ b/src/render/ogc/SDL_render_ogc.c
@@ -384,7 +384,11 @@ static int OGC_RenderClear(SDL_Renderer *renderer, SDL_RenderCommand *cmd)
 
     data->clear_color = c;
     GX_SetCopyClear(c, GX_MAX_Z24);
-    GX_CopyDisp(OGC_video_get_xfb(SDL_GetVideoDevice()), GX_TRUE);
+    if (renderer->target) {
+        save_efb_to_texture(renderer->target);
+    } else {
+        GX_CopyDisp(OGC_video_get_xfb(SDL_GetVideoDevice()), GX_TRUE);
+    }
 
     return 0;
 }


### PR DESCRIPTION
Here's a few changes that fix various issues I've met with a game I'm writing, which makes extensive use of the "render to texture" feature.

Easier to review commit by commit (please don't squash them into merging, since the addressed issues are all slightly different).

I honestly haven't understood why the commit "[ogc: invalidate current texture contents before copying the EFB onto it](https://github.com/devkitPro/SDL/commit/63cb49e6c6d31534a076603285bb23a737d2234f)" is needed, but without it I do see (minor) random corruption on the generated texture.