### PR TITLE
ogc: define weak symbols for opengx functions

### DIFF
--- a/src/video/ogc/SDL_ogcgl.c
+++ b/src/video/ogc/SDL_ogcgl.c
@@ -35,6 +35,21 @@ typedef struct
     int swap_interval;
 } OGC_GL_Context;
 
+/* Weak symbols for the opengx functions used by SDL, so that the client does
+ * not need to link to opengx, unless it actually uses OpenGL. */
+void __attribute__((weak)) ogx_initialize(void)
+{
+    SDL_LogWarn(SDL_LOG_CATEGORY_VIDEO,
+                "%s() called but opengx not used in build!", __func__);
+}
+
+void __attribute__((weak)) *ogx_get_proc_address(const char *)
+{
+    SDL_LogWarn(SDL_LOG_CATEGORY_VIDEO,
+                "%s() called but opengx not used in build!", __func__);
+    return NULL;
+}
+
 int SDL_OGC_GL_LoadLibrary(_THIS, const char *path)
 {
     return 0;


### PR DESCRIPTION
This allows building a client application without linking to opengx, if the client itself does not need OpenGL. The opengx functions used by SDL are defined as weak, so that they will be used only if a strong symbol is not found during linking.

    $ nm /opt/devkitpro/portlibs/wii/lib/libSDL2.a | grep ogx
    00000000 W ogx_get_proc_address
    00000000 W ogx_initialize

Partial fix for #81

Depends on https://github.com/devkitPro/opengx/pull/70