### PR TITLE
wiiu: add USB keyboard support

### DIFF
--- a/src/video/wiiu/SDL_wiiukeyboard.c
+++ b/src/video/wiiu/SDL_wiiukeyboard.c
@@ -109,14 +109,12 @@ void SDL_WIIU_PumpKeyboardEvents(_THIS)
 /* returns non-zero on success */
 int SDL_WIIU_InitKeyboard(_THIS)
 {
-	if (KBDSetup(SDL_WIIUKeyboard_AttachCallback, SDL_WIIUKeyboard_DetachCallback, SDL_WIIUKeyboard_KeyCallback))
+	event_buffer_mutex = SDL_CreateMutex();
+	if (!event_buffer_mutex)
 		return 0;
 
-	event_buffer_mutex = SDL_CreateMutex();
-	if (!event_buffer_mutex) {
-		KBDTeardown();
+	if (KBDSetup(SDL_WIIUKeyboard_AttachCallback, SDL_WIIUKeyboard_DetachCallback, SDL_WIIUKeyboard_KeyCallback))
 		return 0;
-	}
 
 	return 1;
 }

--- a/src/video/wiiu/SDL_wiiukeyboard.c
+++ b/src/video/wiiu/SDL_wiiukeyboard.c
@@ -1,0 +1,126 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2023 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+	  claim that you wrote the original software. If you use this software
+	  in a product, an acknowledgment in the product documentation would be
+	  appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+	  misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#include "SDL_wiiukeyboard.h"
+
+#include "../../SDL_internal.h"
+
+#include "../../events/SDL_keyboard_c.h"
+
+#include <nsyskbd/nsyskbd.h>
+
+#define EVENT_BUFFER_SIZE 10
+
+static struct WIIUKBD_EventBuffer {
+	KBDKeyEvent events[EVENT_BUFFER_SIZE];
+	int current;
+} event_buffer = {0};
+
+/* I'm not sure if this is really necessary, but I'm adding
+ * it anyway in case the wii u calls back from another thread */
+static SDL_mutex *event_buffer_mutex = NULL;
+
+static void SDL_WIIUKeyboard_AttachCallback(KBDAttachEvent *kde)
+{
+	(void)kde;
+}
+
+static void SDL_WIIUKeyboard_DetachCallback(KBDAttachEvent *kde)
+{
+	(void)kde;
+}
+
+static void SDL_WIIUKeyboard_KeyCallback(KBDKeyEvent *e)
+{
+	SDL_LockMutex(event_buffer_mutex);
+
+	/* add the key event to our buffer */
+	if (event_buffer.current < EVENT_BUFFER_SIZE)
+		event_buffer.events[event_buffer.current++] = *e;
+
+	SDL_UnlockMutex(event_buffer_mutex);
+}
+
+void SDL_WIIU_PumpKeyboardEvents(_THIS)
+{
+	int i;
+
+	SDL_LockMutex(event_buffer_mutex);
+
+	/* process each key event */
+	for (i = 0; i < event_buffer.current; i++) {
+		SDL_SendKeyboardKey(
+			event_buffer.events[i].isPressedDown ? SDL_PRESSED : SDL_RELEASED,
+			(SDL_Scancode)event_buffer.events[i].hidCode
+		);
+
+		if (event_buffer.events[i].isPressedDown) {
+			const Uint16 symbol = event_buffer.events[i].asUTF16Character;
+			unsigned char utf8[4] = {0};
+
+			/* convert UCS-2 to UTF-8 */
+			if (symbol < 0x80) {
+				utf8[0] = symbol;
+			} else if (symbol < 0x800) {
+				utf8[0] = 0xC0 | (symbol >> 6);
+				utf8[1] = 0x80 | (symbol & 0x3F);
+			} else {
+				utf8[0] = 0xE0 |  (symbol >> 12);
+				utf8[1] = 0x80 | ((symbol >> 6) & 0x3F);
+				utf8[2] = 0x80 |  (symbol & 0x3F);
+			}
+
+			SDL_SendKeyboardText((char *)utf8);
+		}
+	}
+
+	/* reset the buffer */
+	event_buffer.current = 0;
+
+	SDL_UnlockMutex(event_buffer_mutex);
+}
+
+/* returns non-zero on success */
+int SDL_WIIU_InitKeyboard(_THIS)
+{
+	if (KBDSetup(SDL_WIIUKeyboard_AttachCallback, SDL_WIIUKeyboard_DetachCallback, SDL_WIIUKeyboard_KeyCallback))
+		return 0;
+
+	event_buffer_mutex = SDL_CreateMutex();
+	if (!event_buffer_mutex) {
+		KBDTeardown();
+		return 0;
+	}
+
+	return 1;
+}
+
+/* returns non-zero on success; this should ONLY be called after a successful keyboard init */
+int SDL_WIIU_QuitKeyboard(_THIS)
+{
+	if (KBDTeardown())
+		return 0;
+
+	/* by this point the mutex is definitely not locked */
+	SDL_DestroyMutex(event_buffer_mutex);
+
+	return 1;
+}

--- a/src/video/wiiu/SDL_wiiukeyboard.h
+++ b/src/video/wiiu/SDL_wiiukeyboard.h
@@ -1,8 +1,6 @@
 /*
   Simple DirectMedia Layer
-  Copyright (C) 2018-2018 Ash Logan <ash@heyquark.com>
-  Copyright (C) 2018-2018 Roberto Van Eeden <r.r.qwertyuiop.r.r@gmail.com>
-  Copyright (C) 2022 GaryOderNichts <garyodernichts@gmail.com>
+  Copyright (C) 1997-2023 Sam Lantinga <slouken@libsdl.org>
 
   This software is provided 'as-is', without any express or implied
   warranty.  In no event will the authors be held liable for any damages
@@ -21,40 +19,14 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
+#ifndef SDL_wiiukeyboard_h
+#define SDL_wiiukeyboard_h
+
 #include "../../SDL_internal.h"
+#include "../../events/SDL_events_c.h"
 
-#ifndef SDL_wiiuvideo_h
-#define SDL_wiiuvideo_h
+void SDL_WIIU_PumpKeyboardEvents(_THIS);
+int SDL_WIIU_InitKeyboard(_THIS);
+int SDL_WIIU_QuitKeyboard(_THIS);
 
-#if SDL_VIDEO_DRIVER_WIIU
-
-#include <gx2/surface.h>
-
-typedef struct WIIU_VideoData WIIU_VideoData;
-
-struct WIIU_VideoData
-{
-	// indicate if we're handling procui in SDL's events
-	SDL_bool handleProcUI;
-
-	SDL_bool hasForeground;
-
-	void *commandBufferPool;
-
-	GX2TVRenderMode tvRenderMode;
-	uint32_t tvWidth;
-	uint32_t tvHeight;
-	void *tvScanBuffer;
-	uint32_t tvScanBufferSize;
-
-	GX2DrcRenderMode drcRenderMode;
-	void *drcScanBuffer;
-	uint32_t drcScanBufferSize;
-
-   // did the keyboard code initialize properly?
-   int kbd_init;
-};
-
-#endif /* SDL_VIDEO_DRIVER_WIIU */
-
-#endif /* SDL_wiiuvideo_h */
+#endif /* SDL_wiiukeyboard_h */

--- a/src/video/wiiu/SDL_wiiuvideo.c
+++ b/src/video/wiiu/SDL_wiiuvideo.c
@@ -36,6 +36,7 @@
 #include "../../events/SDL_keyboard_c.h"
 #include "../../events/SDL_events_c.h"
 #include "SDL_wiiuvideo.h"
+#include "SDL_wiiukeyboard.h"
 #include "SDL_wiiu_gfx_heap.h"
 
 #include "../../render/wiiu/SDL_render_wiiu.h"
@@ -269,6 +270,8 @@ static int WIIU_VideoInit(_THIS)
 	mode.refresh_rate = 60;
 	SDL_AddBasicVideoDisplay(&mode);
 
+	videodata->kbd_init = SDL_WIIU_InitKeyboard(_this);
+
 	return 0;
 }
 
@@ -292,6 +295,9 @@ static void WIIU_VideoQuit(_THIS)
 	if (videodata->handleProcUI) {
 		ProcUIShutdown();
 	}
+
+	if (videodata->kbd_init)
+		SDL_WIIU_QuitKeyboard(_this);
 
 	running = SDL_FALSE;
 }
@@ -335,6 +341,8 @@ static void WIIU_PumpEvents(_THIS)
 			ProcUIDrawDoneRelease();
 		}
 	}
+
+	SDL_WIIU_PumpKeyboardEvents(_this);
 }
 
 static void WIIU_DeleteDevice(SDL_VideoDevice *device)


### PR DESCRIPTION
This PR adds USB keyboard support via the `nsyskbd` library. All of the keyboard code is consolidated into `SDL_wiiukeyboard.c`.

The Wii U doesn't provide an easy way to just poll for keyboard events, so I put in a "event queue" of sorts that gets processed when events are polled. The queue is hardcoded to a maximum of ten events (but can be changed easily). It may not even be necessary to do it that way anyway, since the keyboard code will only realistically be called by that thread, but I'd rather be safe than sorry.