### PR TITLE
ogc: add OpenGL stencil support

### DIFF
--- a/src/video/ogc/SDL_ogcgl.c
+++ b/src/video/ogc/SDL_ogcgl.c
@@ -43,11 +43,24 @@ void __attribute__((weak)) ogx_initialize(void)
                 "%s() called but opengx not used in build!", __func__);
 }
 
+void __attribute__((weak)) ogx_stencil_create(OgxStencilFlags)
+{
+    SDL_LogWarn(SDL_LOG_CATEGORY_VIDEO,
+                "%s() called but opengx not used in build!", __func__);
+}
+
 void __attribute__((weak)) *ogx_get_proc_address(const char *)
 {
     SDL_LogWarn(SDL_LOG_CATEGORY_VIDEO,
                 "%s() called but opengx not used in build!", __func__);
     return NULL;
+}
+
+int __attribute__((weak)) ogx_prepare_swap_buffers()
+{
+    SDL_LogWarn(SDL_LOG_CATEGORY_VIDEO,
+                "%s() called but opengx not used in build!", __func__);
+    return 0;
 }
 
 int SDL_OGC_GL_LoadLibrary(_THIS, const char *path)
@@ -71,6 +84,11 @@ SDL_GLContext SDL_OGC_GL_CreateContext(_THIS, SDL_Window * window)
     context->window = window;
     context->swap_interval = 1;
     ogx_initialize();
+    if (_this->gl_config.stencil_size > 0) {
+        OgxStencilFlags flags = 0; /* Don't care if Z gets dirty on discarded fragments */
+        if (_this->gl_config.stencil_size > 4) flags |= OGX_STENCIL_8BIT;
+        ogx_stencil_create(flags);
+    }
     return context;
 }
 

--- a/src/video/ogc/SDL_ogcvideo.c
+++ b/src/video/ogc/SDL_ogcvideo.c
@@ -42,6 +42,8 @@
 #include <ogc/system.h>
 #include <ogc/video.h>
 
+#include <opengx.h>
+
 #define DEFAULT_FIFO_SIZE 256 * 1024
 
 // Inverse of the VI_TVMODE macro

--- a/src/video/ogc/SDL_ogcvideo.c
+++ b/src/video/ogc/SDL_ogcvideo.c
@@ -343,6 +343,8 @@ void OGC_video_flip(_THIS, bool vsync)
     SDL_VideoData *videodata = _this->driverdata;
     void *xfb = OGC_video_get_xfb(_this);
 
+    if (ogx_prepare_swap_buffers() < 0) return;
+
 #ifdef __wii__
     OGC_draw_cursor(_this);
 #endif


### PR DESCRIPTION
opengx needs to be informed if a stencil buffer is desired (and about its desired depth, too). Also inform opengx when we want to swap a frame, to ensure that the drawing buffer is currently selected (and not the stencil one).
