### PR TITLE
ogc: Fix timer precision

### DIFF
--- a/src/timer/ogc/SDL_systimer.c
+++ b/src/timer/ogc/SDL_systimer.c
@@ -53,12 +53,12 @@ Uint64 SDL_GetTicks64(void)
 
 Uint64 SDL_GetPerformanceCounter(void)
 {
-    return SDL_GetTicks64();
+    return gettime();
 }
 
 Uint64 SDL_GetPerformanceFrequency(void)
 {
-    return 1000;
+    return secs_to_ticks(1);
 }
 
 void SDL_Delay(Uint32 ms)


### PR DESCRIPTION
`SDL_GetPerformanceCounter` is supposed to return the value of a high precision counter, but `SDL_GetTicks64` returns a truncated value in milliseconds.
Correctly return `gettime()` as a high precision counter instead, and update `SDL_GetPerformanceFrequency` accordingly.
