### PR TITLE
wiiu/video: Support 4:3 video mode

### DIFF
--- a/src/video/wiiu/SDL_wiiuvideo.c
+++ b/src/video/wiiu/SDL_wiiuvideo.c
@@ -211,9 +211,15 @@ static int WIIU_VideoInit(_THIS)
 	switch(GX2GetSystemTVScanMode()) {
 	case GX2_TV_SCAN_MODE_480I:
 	case GX2_TV_SCAN_MODE_480P:
-		videodata->tvRenderMode = GX2_TV_RENDER_MODE_WIDE_480P;
-		videodata->tvWidth = 854;
-		videodata->tvHeight = 480;
+		if (GX2GetSystemTVAspectRatio() == GX2_ASPECT_RATIO_16_9) {
+			videodata->tvRenderMode = GX2_TV_RENDER_MODE_WIDE_480P;
+			videodata->tvWidth = 854;
+			videodata->tvHeight = 480;
+		} else {
+			videodata->tvRenderMode = GX2_TV_RENDER_MODE_STANDARD_480P;
+			videodata->tvWidth = 640;
+			videodata->tvHeight = 480;
+		}
 		break;
 	case GX2_TV_SCAN_MODE_1080I:
 	case GX2_TV_SCAN_MODE_1080P:


### PR DESCRIPTION
Basic support for rendering with a 4:3 TV rendering mode, needs further testing.