### PR TITLE
wiiu: Improve SDL_UpdateTexture performance + add max texture size

### DIFF
--- a/src/render/wiiu/SDL_render_wiiu.c
+++ b/src/render/wiiu/SDL_render_wiiu.c
@@ -360,8 +360,8 @@ SDL_RenderDriver WIIU_RenderDriver =
 
             SDL_PIXELFORMAT_ARGB2101010,
         },
-        .max_texture_width = 0,
-        .max_texture_height = 0,
+        .max_texture_width = 8192,
+        .max_texture_height = 8192,
     },
 };
 


### PR DESCRIPTION
`SDL_UpdateTexture` is often used in software rendered games for uploading the game's current framebuffer to the GPU for display. This PR greatly improves performance by using optimized memory copy routines from the OS and DMA transfer when possible.
Speedup is anywhere between 1.5x and 15x faster than the original implementation.

This PR also adds the missing max texture size for games that might rely on it, based on AMD GPU documentation close to GX2 found here: https://www.x.org/docs/AMD/old/R6xx_R7xx_3D.pdf.