### PR TITLE
Wii U: Clean up ProcUI on exit.

### DIFF
--- a/src/video/wiiu/SDL_wiiuvideo.c
+++ b/src/video/wiiu/SDL_wiiuvideo.c
@@ -281,7 +281,7 @@ static void WIIU_VideoQuit(_THIS)
 	WIIU_VideoData *videodata = (WIIU_VideoData *) _this->driverdata;
 
 	if (videodata->handleProcUI) {
-		// make sure to clean up ProcUI if user stopped processing events
+		// Put ProcUI into EXIT/shutdown state if user stopped processing events
 		// before SDL_QUIT was generated.
 		if (ProcUIIsRunning() && !ProcUIInShutdown()) {
 			SDL_bool procui_running = SDL_TRUE;
@@ -355,7 +355,7 @@ static void WIIU_PumpEvents(_THIS)
 {
 	WIIU_VideoData *videodata = (WIIU_VideoData *) _this->driverdata;
 
-	if (videodata->handleProcUI) {
+	if (videodata->handleProcUI && !ProcUIInShutdown()) {
 		ProcUIStatus status = ProcUIProcessMessages(TRUE);
 		if (status == PROCUI_STATUS_EXITING) {
 			SDL_SendQuit();


### PR DESCRIPTION
This PR finishes processing ProcUI when the application breaks out of the main loop before seeing `SDL_QUIT`. This is a common pattern when the player chooses a "quit" option from a menu.

The cleanup is triggered by `SDL_Quit()`, and only happens if SDL itself initialized ProcUI.