### PR TITLE
Wii U: Implemented FOREGROUND/BACKGROUND events.

### DIFF
--- a/src/video/wiiu/SDL_wiiuvideo.c
+++ b/src/video/wiiu/SDL_wiiuvideo.c
@@ -370,7 +370,7 @@ static void WIIU_PumpEvents(_THIS)
 				}
 				SDL_SendAppEvent(SDL_APP_WILLENTERBACKGROUND);
 				SDL_SendAppEvent(SDL_APP_DIDENTERBACKGROUND);
-				// Note: we don't cal ProcUIDrawDoneRelease() here to give
+				// Note: we don't call ProcUIDrawDoneRelease() here to give
 				// the application a chance to receive and process the
 				// events queued above. The next call to WIIU_PumpEvents()
 				// is the one that actually enters the background.

--- a/src/video/wiiu/SDL_wiiuvideo.c
+++ b/src/video/wiiu/SDL_wiiuvideo.c
@@ -101,8 +101,10 @@ static int WIIU_ForegroundAcquired(_THIS)
 	GX2Invalidate(GX2_INVALIDATE_MODE_CPU, videodata->drcScanBuffer, videodata->drcScanBufferSize);
 	GX2SetDRCBuffer(videodata->drcScanBuffer, videodata->drcScanBufferSize, videodata->drcRenderMode, GX2_SURFACE_FORMAT_UNORM_R8_G8_B8_A8, GX2_BUFFERING_MODE_DOUBLE);
 
-	SDL_SendAppEvent(SDL_APP_WILLENTERFOREGROUND);
-	SDL_SendAppEvent(SDL_APP_DIDENTERFOREGROUND);
+	if (videodata->handleProcUI) {
+		SDL_SendAppEvent(SDL_APP_WILLENTERFOREGROUND);
+		SDL_SendAppEvent(SDL_APP_DIDENTERFOREGROUND);
+	}
 
 	while (window) {
 		SDL_Renderer* renderer = SDL_GetRenderer(window);
@@ -148,6 +150,15 @@ static int WIIU_ForegroundReleased(_THIS)
 
 	while (window) {
 		SDL_Renderer* renderer = SDL_GetRenderer(window);
+
+		// Avoid sending the event if we're handling ProcUI, since we send this
+		// event from inside WIIU_PumpEvents().
+		// Note: the application won't receive this event until after we return to
+		// the foreground.
+		if (!videodata->handleProcUI) {
+			// No longer in foreground, window is no longer visible.
+			SDL_SendWindowEvent(window, SDL_WINDOWEVENT_HIDDEN, 0, 0);
+		}
 
 		// Destroy window texture, we no longer have access to foreground memory
 		if (renderer) {
@@ -336,6 +347,7 @@ static void WIIU_PumpEvents(_THIS)
 	if (videodata->enteringBackground) {
 		// The previous ProcUIProcessMessages() received a
 		// PROCUI_STATUS_RELEASE_FOREGROUND.
+		// Note: enteringBackground can only become true if handleProcUI is true.
 		videodata->enteringBackground = SDL_FALSE;
 		ProcUIDrawDoneRelease();
 	}
@@ -351,13 +363,17 @@ static void WIIU_PumpEvents(_THIS)
 		case PROCUI_STATUS_RELEASE_FOREGROUND: {
 			SDL_Window* window = _this->windows;
 			while (window) {
-				// No longer in foreground, window is no longer visible
+				// No longer in foreground, window is no longer visible.
 				SDL_SendWindowEvent(window, SDL_WINDOWEVENT_HIDDEN, 0, 0);
 				window = window->next;
 			}
-			videodata->enteringBackground = SDL_TRUE;
 			SDL_SendAppEvent(SDL_APP_WILLENTERBACKGROUND);
 			SDL_SendAppEvent(SDL_APP_DIDENTERBACKGROUND);
+			// Note: we don't cal ProcUIDrawDoneRelease() here to give the
+			// application a chance to receive and process the events queued
+			// above. The next call to WIIU_PumpEvents() is the one that
+			// actually enters the background.
+			videodata->enteringBackground = SDL_TRUE;
 			break;
 		}
 		case PROCUI_STATUS_EXITING:

--- a/src/video/wiiu/SDL_wiiuvideo.h
+++ b/src/video/wiiu/SDL_wiiuvideo.h
@@ -38,6 +38,7 @@ struct WIIU_VideoData
 	SDL_bool handleProcUI;
 
 	SDL_bool hasForeground;
+	SDL_bool enteringBackground;
 
 	void *commandBufferPool;
 


### PR DESCRIPTION
This PR implements the following SDL events:
- `SDL_APP_WILLENTERBACKGROUND`
- `SDL_APP_DIDENTERBACKGROUND`
- `SDL_APP_WILLENTERFOREGROUND`
- `SDL_APP_DIDENTERFOREGROUND`

## Description

To allow the application to see the background events *before* it's suspended in the background, the call to `ProcUIDrawDoneRelease()` is deferred to the next call of `WIIU_PumpEvents()`.

The `SDL_WINDOWEVENT_HIDDEN` messages were moved from the `WIIU_ForegroundReleased()` callback to `WIIU_PumpEvents()`, so they're also delivered to the application before transition to the background happen.

The order of events received by the application when entering backgrounds is:
```
SDL_WINDOWEVENT / SDL_WINDOWEVENT_SIZE_CHANGED
SDL_WINDOWEVENT / SDL_WINDOWEVENT_HIDDEN
SDL_APP_WILLENTERBACKGROUND
SDL_APP_DIDENTERBACKGROUND
```
Then the next call to `SDL_PollEvent()` will block until it either returns to the foreground or exit is requested.

When entering the foreground, the order of events is:
```
SDL_APP_WILLENTERFOREGROUND
SDL_APP_DIDENTERFOREGROUND
SDL_WINDOWEVENT / SDL_WINDOWEVENT_SIZE_CHANGED
SDL_WINDOWEVENT / SDL_WINDOWEVENT_SHOWN
```

When quitting the application from the Home Button Menu, the only event delivered is `SDL_QUIT`. An extra check was added to avoid processing ProcUI messages past the exit condition.