### PR TITLE
Wii U: Fixed render to texture lag problem (#103)

### DIFF
--- a/src/render/wiiu/SDL_render_wiiu.c
+++ b/src/render/wiiu/SDL_render_wiiu.c
@@ -194,16 +194,23 @@ int WIIU_SDL_SetRenderTarget(SDL_Renderer * renderer, SDL_Texture * texture)
         return 0;
     }
 
+    /* Already in use */
+    if (data->curTarget == tdata) {
+        return 0;
+    }
+
     /* make sure we're using the correct renderer ctx */
     GX2SetContextState(data->ctx);
 
     /* Wait for the texture rendering to finish if it is still in use by the GPU */
-    if (WIIU_TextureInUse(data, tdata)) {
+    /*if (WIIU_TextureInUse(data, tdata)) {
         WIIU_TextureWaitDone(data, tdata);
-    }
+    }*/
 
     /* Update context state */
     GX2SetColorBuffer(&tdata->cbuf, GX2_RENDER_TARGET_0);
+
+    data->curTarget = tdata;
 
     return 0;
 }

--- a/src/render/wiiu/SDL_render_wiiu.h
+++ b/src/render/wiiu/SDL_render_wiiu.h
@@ -89,6 +89,7 @@ struct WIIU_RenderData
     OSTime lastFrameTimestamp;
     SDL_Texture windowTex;
     WIIU_DrawState drawState;
+    WIIU_TextureData *curTarget;
 };
 
 struct WIIU_TextureData

--- a/src/render/wiiu/SDL_rpresent_wiiu.c
+++ b/src/render/wiiu/SDL_rpresent_wiiu.c
@@ -80,6 +80,8 @@ int WIIU_SDL_RenderPresent(SDL_Renderer * renderer)
         tvDrcEnabled = SDL_TRUE;
     }
 
+    data->curTarget = NULL;
+
     return 0;
 }
 


### PR DESCRIPTION
Fixed the problem of lag caused by the wait inside the "Set Render Target" function.

The wait operation here is unnecessary since the render-to-texture is fully GPU-side operation, and no software manipulations were done with the texture on the software side during this case. Additionally, such operation leads to a serious lag in result.

## Description
Before fix (Pay attention on left-top debug info, and the value of GFX - it's a time spent on the graphics render operation, it goes above 1000):
![2025-06-23_20 04 17 590_TV](https://github.com/user-attachments/assets/97ce55ad-0a0f-46c6-b223-f20e2c45d4af)

After fix (Now the time spent to draw the SAME scene is lesser than 500!):
![2025-06-23_22 00 34 098_TV](https://github.com/user-attachments/assets/e2642f9d-2bd2-4718-921d-709709969ab5)

## Existing Issue(s)
#103

