### PR TITLE
Replaced the call of WIIU_SDL_SetRenderTarget with the GX2SetContextState

### DIFF
--- a/src/render/wiiu/SDL_rqueue_wiiu.c
+++ b/src/render/wiiu/SDL_rqueue_wiiu.c
@@ -374,7 +374,7 @@ int WIIU_SDL_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, vo
     }
 
     /* make sure we're using the correct renderer ctx */
-    WIIU_SDL_SetRenderTarget(renderer, renderer->target);
+    GX2SetContextState(data->ctx);
 
     data->drawState.target = renderer->target;
     if (!data->drawState.target) {


### PR DESCRIPTION
It's unnecessary to call the WIIU_SDL_SetRenderTarget at WIIU_SDL_RunCommandQueue for every time the function is called. It's enough to call the GX2SetContextState if it's a necessary to run this operation here.

## Existing Issue(s)
It's addition to PR #105 to make it more completed after changes done over.