### PR TITLE
Wii U / Video: Fixed resume of video afrer the home menu close

### DIFF
--- a/src/video/wiiu/SDL_wiiuvideo.c
+++ b/src/video/wiiu/SDL_wiiuvideo.c
@@ -57,6 +57,7 @@
 #include <gx2/state.h>
 #include <gx2r/mem.h>
 #include <gx2r/surface.h>
+#include <gx2/swap.h>
 
 #define DRC_SCREEN_WIDTH    854
 #define DRC_SCREEN_HEIGHT   480
@@ -105,6 +106,9 @@ static int WIIU_ForegroundAcquired(_THIS)
 	if (videodata->handleProcUI) {
 		SDL_SendAppEvent(SDL_APP_WILLENTERFOREGROUND);
 		SDL_SendAppEvent(SDL_APP_DIDENTERFOREGROUND);
+		if (GX2GetSwapInterval() == 0) {
+			GX2SetSwapInterval(0); /* If V-Sync is disabled, to let render not freeze, call this method with 0 */
+		}
 	}
 
 	while (window) {

--- a/src/video/wiiu/SDL_wiiuvideo.c
+++ b/src/video/wiiu/SDL_wiiuvideo.c
@@ -106,9 +106,10 @@ static int WIIU_ForegroundAcquired(_THIS)
 	if (videodata->handleProcUI) {
 		SDL_SendAppEvent(SDL_APP_WILLENTERFOREGROUND);
 		SDL_SendAppEvent(SDL_APP_DIDENTERFOREGROUND);
-		if (GX2GetSwapInterval() == 0) {
-			GX2SetSwapInterval(0); /* If V-Sync is disabled, to let render not freeze, call this method with 0 */
-		}
+	}
+
+	if (GX2GetSwapInterval() == 0) {
+		GX2SetSwapInterval(0); /* Workaround for leaving foreground with a swap interval 0 */
 	}
 
 	while (window) {


### PR DESCRIPTION
This bug happens just when V-Sync is off and attempting to open and close the home menu. To fix the black/frozen screen it's just enough to call the `GX2SetSwapInterval(0);` right after entering the foreground back.

P.S. I checked on the WUT side, and seems, such workaround is required since it's a bug of the Wii U firmware itself.

## Description

Demo of buggy behaviour at [my project](https://github.com/TheXTech/TheXTech/):

https://github.com/user-attachments/assets/1e4ee887-b16c-4c35-90de-9d97fa485982

Demo of the fixed behaviour at my project:

https://github.com/user-attachments/assets/889f8510-17f2-452d-8f93-905657cbc076

Unexpectedly, this bug affects the EasyRPG (ping @Ghabry to use the newer SDL2 for Wii U after this fix arrive) too when disabling V-Sync, and re-enabling V-Sync restores back the screen:

https://github.com/user-attachments/assets/9e621ef1-8472-4a0d-9615-a04f26338320




