### PR TITLE
switch [sdl2]: fix guards

### DIFF
--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -111,7 +111,7 @@ static const AudioBootStrap *const bootstrap[] = {
 #if SDL_AUDIO_DRIVER_EMSCRIPTEN
     &EMSCRIPTENAUDIO_bootstrap,
 #endif
-#if SDL_AUDIO_DRIVER_SWITCH
+#ifdef SDL_AUDIO_DRIVER_SWITCH
     &SWITCHAUDIO_bootstrap,
 #endif
 #if SDL_AUDIO_DRIVER_JACK

--- a/src/audio/switch/SDL_switchaudio.c
+++ b/src/audio/switch/SDL_switchaudio.c
@@ -20,7 +20,7 @@
 */
 #include "../../SDL_internal.h"
 
-#if SDL_AUDIO_DRIVER_SWITCH
+#ifdef SDL_AUDIO_DRIVER_SWITCH
 
 #include <stdio.h>
 #include <string.h>

--- a/src/joystick/SDL_gamecontrollerdb.h
+++ b/src/joystick/SDL_gamecontrollerdb.h
@@ -992,7 +992,7 @@ static const char *s_ControllerMappings[] = {
 #if SDL_JOYSTICK_N3DS
     "000000004e696e74656e646f20334400,Nintendo 3DS,crc:3210,a:b0,b:b1,back:b2,dpdown:b7,dpleft:b5,dpright:b4,dpup:b6,leftshoulder:b9,lefttrigger:b14,leftx:a0,lefty:a1,rightshoulder:b8,righttrigger:b15,rightx:a2,righty:a3,start:b3,x:b10,y:b11,",
 #endif
-#if defined(SDL_JOYSTICK_SWITCH)
+#ifdef SDL_JOYSTICK_SWITCH
     "000038f853776974636820436f6e7400,Switch Controller,a:b1,b:b0,back:b11,dpdown:b15,dpleft:b12,dpright:b14,dpup:b13,leftshoulder:b6,leftstick:b4,lefttrigger:b8,leftx:a0,lefty:a1,rightshoulder:b7,rightstick:b5,righttrigger:b9,rightx:a2,righty:a3,start:b10,x:b3,y:b2,",
 #endif
     "hidapi,*,a:b0,b:b1,back:b4,dpdown:b12,dpleft:b13,dpright:b14,dpup:b11,guide:b5,leftshoulder:b9,leftstick:b7,lefttrigger:a4,leftx:a0,lefty:a1,rightshoulder:b10,rightstick:b8,righttrigger:a5,rightx:a2,righty:a3,start:b6,x:b2,y:b3,",

--- a/src/joystick/switch/SDL_sysjoystick.c
+++ b/src/joystick/switch/SDL_sysjoystick.c
@@ -20,7 +20,7 @@
 */
 #include "../../SDL_internal.h"
 
-#if SDL_JOYSTICK_SWITCH
+#ifdef SDL_JOYSTICK_SWITCH
 
 /* This is the dummy implementation of the SDL joystick API */
 

--- a/src/power/switch/SDL_syspower.c
+++ b/src/power/switch/SDL_syspower.c
@@ -22,7 +22,7 @@
 #include "../../SDL_internal.h"
 
 #ifndef SDL_POWER_DISABLED
-#if SDL_POWER_SWITCH
+#ifdef SDL_POWER_SWITCH
 
 #include <switch.h>
 #include "SDL_power.h"

--- a/src/thread/SDL_thread_c.h
+++ b/src/thread/SDL_thread_c.h
@@ -46,7 +46,7 @@
 #include "os2/SDL_systhread_c.h"
 #elif SDL_THREAD_NGAGE
 #include "ngage/SDL_systhread_c.h"
-#elif SDL_THREAD_SWITCH
+#elif defined(SDL_THREAD_SWITCH)
 #include "switch/SDL_systhread_c.h"
 #else
 #error Need thread implementation for this platform

--- a/src/thread/pthread/SDL_systhread.c
+++ b/src/thread/pthread/SDL_systhread.c
@@ -128,7 +128,7 @@ void SDL_SYS_SetupThread(const char *name)
 #if !defined(__NACL__) && !defined(__SWITCH__)
     int i;
     sigset_t mask;
-#endif /* !__NACL__ && !__NINTENDO_SWITCH__ */
+#endif /* !__NACL__ && !__SWITCH__ */
 
     if (name != NULL) {
         #if (defined(__MACOSX__) || defined(__IPHONEOS__) || defined(__LINUX__)) && defined(HAVE_DLOPEN)
@@ -172,7 +172,7 @@ void SDL_SYS_SetupThread(const char *name)
         sigaddset(&mask, sig_list[i]);
     }
     pthread_sigmask(SIG_BLOCK, &mask, 0);
-#endif /* !__NACL__ && !__NINTENDO_SWITCH__ */
+#endif /* !__NACL__ && !__SWITCH__ */
 
 
 #ifdef PTHREAD_CANCEL_ASYNCHRONOUS
@@ -194,7 +194,7 @@ int SDL_SYS_SetThreadPriority(SDL_ThreadPriority priority)
 #if __NACL__ || __RISCOS__ || __OS2__
     /* FIXME: Setting thread priority does not seem to be supported in NACL */
     return 0;
-#elif __SWITCH__
+#elif defined(__SWITCH__)
     Result res;
     if (priority == SDL_THREAD_PRIORITY_HIGH) {
         res = svcSetThreadPriority(CUR_THREAD_HANDLE, 0x2B);

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -205,7 +205,7 @@ typedef struct
 
 static Uint32 SDL_DefaultGraphicsBackends(SDL_VideoDevice *_this)
 {
-#if (SDL_VIDEO_OPENGL && __MACOSX__) || (__IPHONEOS__ && !TARGET_OS_MACCATALYST) || __ANDROID__ || __NACL__ || __SWITCH__
+#if (SDL_VIDEO_OPENGL && __MACOSX__) || (__IPHONEOS__ && !TARGET_OS_MACCATALYST) || __ANDROID__ || __NACL__ || defined(__SWITCH__)
     if (_this->GL_CreateContext != NULL) {
         return SDL_WINDOW_OPENGL;
     }

--- a/src/video/switch/SDL_switchkeyboard.c
+++ b/src/video/switch/SDL_switchkeyboard.c
@@ -20,7 +20,7 @@
 */
 #include "../../SDL_internal.h"
 
-#if SDL_VIDEO_DRIVER_SWITCH
+#ifdef SDL_VIDEO_DRIVER_SWITCH
 
 #include <switch.h>
 

--- a/src/video/switch/SDL_switchmouse.c
+++ b/src/video/switch/SDL_switchmouse.c
@@ -20,7 +20,7 @@
 */
 #include "../../SDL_internal.h"
 
-#if SDL_VIDEO_DRIVER_SWITCH
+#ifdef SDL_VIDEO_DRIVER_SWITCH
 
 #include <switch.h>
 

--- a/src/video/switch/SDL_switchopengles.c
+++ b/src/video/switch/SDL_switchopengles.c
@@ -22,7 +22,7 @@
 #include "../../SDL_internal.h"
 #include "SDL_log.h"
 
-#if SDL_VIDEO_DRIVER_SWITCH
+#if defined(SDL_VIDEO_DRIVER_SWITCH) && defined(SDL_VIDEO_OPENGL_EGL)
 
 #include "SDL_video.h"
 #include "SDL_switchopengles.h"
@@ -48,6 +48,6 @@ SDL_EGL_CreateContext_impl(SWITCH)
 SDL_EGL_MakeCurrent_impl(SWITCH)
 SDL_EGL_SwapWindow_impl(SWITCH)
 
-#endif /* SDL_VIDEO_DRIVER_SWITCH */
+#endif /* SDL_VIDEO_DRIVER_SWITCH && SDL_VIDEO_OPENGL_EGL*/
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/video/switch/SDL_switchopengles.h
+++ b/src/video/switch/SDL_switchopengles.h
@@ -23,7 +23,7 @@
 #ifndef SDL_switchteopengles_h_
 #define SDL_switchteopengles_h_
 
-#if SDL_VIDEO_DRIVER_SWITCH
+#ifdef SDL_VIDEO_OPENGL_EGL
 
 #include "../SDL_sysvideo.h"
 #include "../SDL_egl_c.h"
@@ -43,7 +43,7 @@ extern int SWITCH_GLES_MakeCurrent(_THIS, SDL_Window *window, SDL_GLContext cont
 extern void SWITCH_GLES_DefaultProfileConfig(_THIS, int *mask, int *major, int *minor);
 extern void SWITCH_GLES_GetDrawableSize(_THIS, SDL_Window *window, int *w, int *h);
 
-#endif /* SDL_VIDEO_DRIVER_SWITCH */
+#endif /* SDL_VIDEO_OPENGL_EGL */
 #endif /* SDL_switchteopengles_h_ */
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/video/switch/SDL_switchswkb.c
+++ b/src/video/switch/SDL_switchswkb.c
@@ -4,7 +4,7 @@
 
 #include "../../SDL_internal.h"
 
-#if SDL_VIDEO_DRIVER_SWITCH
+#ifdef SDL_VIDEO_DRIVER_SWITCH
 
 #include <switch.h>
 #include "SDL_switchswkb.h"
@@ -108,4 +108,4 @@ SWITCH_StopTextInput(_THIS)
     kbdShown = false;
 }
 
-#endif
+#endif // SDL_VIDEO_DRIVER_SWITCH

--- a/src/video/switch/SDL_switchtouch.c
+++ b/src/video/switch/SDL_switchtouch.c
@@ -20,7 +20,7 @@
 */
 #include "../../SDL_internal.h"
 
-#if SDL_VIDEO_DRIVER_SWITCH
+#ifdef SDL_VIDEO_DRIVER_SWITCH
 
 #include <switch.h>
 

--- a/src/video/switch/SDL_switchvideo.c
+++ b/src/video/switch/SDL_switchvideo.c
@@ -21,7 +21,7 @@
 
 #include "../../SDL_internal.h"
 
-#if SDL_VIDEO_DRIVER_SWITCH
+#ifdef SDL_VIDEO_DRIVER_SWITCH
 
 #include "../SDL_sysvideo.h"
 #include "../../render/SDL_sysrender.h"
@@ -89,7 +89,7 @@ SWITCH_CreateDevice()
     //device->SetWindowMouseGrab = SWITCH_SetWindowGrab; // SDL 2.0.16
     //device->SetWindowKeyboardGrab = SWITCH_SetWindowGrab; // SDL 2.0.16
     device->DestroyWindow = SWITCH_DestroyWindow;
-
+#ifdef SDL_VIDEO_OPENGL_EGL
     device->GL_LoadLibrary = SWITCH_GLES_LoadLibrary;
     device->GL_GetProcAddress = SWITCH_GLES_GetProcAddress;
     device->GL_UnloadLibrary = SWITCH_GLES_UnloadLibrary;
@@ -100,7 +100,7 @@ SWITCH_CreateDevice()
     device->GL_SwapWindow = SWITCH_GLES_SwapWindow;
     device->GL_DeleteContext = SWITCH_GLES_DeleteContext;
     device->GL_DefaultProfileConfig = SWITCH_GLES_DefaultProfileConfig;
-
+#endif
     device->StartTextInput = SWITCH_StartTextInput;
     device->StopTextInput = SWITCH_StopTextInput;
     device->HasScreenKeyboardSupport = SWITCH_HasScreenKeyboardSupport;
@@ -156,13 +156,14 @@ SWITCH_VideoInit(_THIS)
 void
 SWITCH_VideoQuit(_THIS)
 {
+#ifdef SDL_VIDEO_OPENGL_EGL
     // this should not be needed if user code is right (SDL_GL_LoadLibrary/SDL_GL_UnloadLibrary calls match)
     // this (user) error doesn't have the same effect on switch thought, as the driver needs to be unloaded (crash)
     if(_this->gl_config.driver_loaded > 0) {
         SWITCH_GLES_UnloadLibrary(_this);
         _this->gl_config.driver_loaded = 0;
     }
-
+#endif
     // exit touch
     SWITCH_QuitTouch();
     // exit keyboard
@@ -195,6 +196,7 @@ SWITCH_GetDisplayModes(_THIS, SDL_VideoDisplay *display)
 int
 SWITCH_SetDisplayMode(_THIS, SDL_VideoDisplay *display, SDL_DisplayMode *mode)
 {
+#ifdef SDL_VIDEO_OPENGL_EGL
     SDL_WindowData *data = (SDL_WindowData *) SDL_GetFocusWindow()->driverdata;
     SDL_GLContext ctx = SDL_GL_GetCurrentContext();
     NWindow *nWindow = nwindowGetDefault();
@@ -206,7 +208,7 @@ SWITCH_SetDisplayMode(_THIS, SDL_VideoDisplay *display, SDL_DisplayMode *mode)
         data->egl_surface = SDL_EGL_CreateSurface(_this, nWindow);
         SDL_EGL_MakeCurrent(_this, data->egl_surface, ctx);
     }
-
+#endif
     return 0;
 }
 
@@ -214,13 +216,15 @@ int
 SWITCH_CreateWindow(_THIS, SDL_Window *window)
 {
     Result rc;
+#ifdef SDL_VIDEO_OPENGL_EGL
     SDL_WindowData *window_data = NULL;
+#endif
     NWindow *nWindow = NULL;
 
     if (switch_window != NULL) {
         return SDL_SetError("Switch only supports one window");
     }
-
+#ifdef SDL_VIDEO_OPENGL_EGL
     if (!_this->egl_data) {
         return SDL_SetError("EGL not initialized");
     }
@@ -229,14 +233,14 @@ SWITCH_CreateWindow(_THIS, SDL_Window *window)
     if (window_data == NULL) {
         return SDL_OutOfMemory();
     }
-
+#endif
     nWindow = nwindowGetDefault();
 
     rc = nwindowSetDimensions(nWindow, window->w, window->h);
     if (R_FAILED(rc)) {
         return SDL_SetError("Could not set NWindow dimensions: 0x%x", rc);
     }
-
+#ifdef SDL_VIDEO_OPENGL_EGL
     window_data->egl_surface = SDL_EGL_CreateSurface(_this, nWindow);
     if (window_data->egl_surface == EGL_NO_SURFACE) {
         return SDL_SetError("Could not create GLES window surface");
@@ -244,6 +248,7 @@ SWITCH_CreateWindow(_THIS, SDL_Window *window)
 
     /* Setup driver data for this window */
     window->driverdata = window_data;
+#endif
     switch_window = window;
 
     /* starting operation mode */
@@ -260,9 +265,9 @@ SWITCH_CreateWindow(_THIS, SDL_Window *window)
 void
 SWITCH_DestroyWindow(_THIS, SDL_Window *window)
 {
-    SDL_WindowData *data = (SDL_WindowData *) window->driverdata;
-
     if (window == switch_window) {
+#ifdef SDL_VIDEO_OPENGL_EGL
+        SDL_WindowData *data = (SDL_WindowData *) window->driverdata;
         if (data != NULL) {
             if (data->egl_surface != EGL_NO_SURFACE) {
                 SDL_EGL_MakeCurrent(_this, NULL, NULL);
@@ -273,6 +278,7 @@ SWITCH_DestroyWindow(_THIS, SDL_Window *window)
                 window->driverdata = NULL;
             }
         }
+#endif
         switch_window = NULL;
     }
 }
@@ -297,6 +303,7 @@ SWITCH_SetWindowPosition(_THIS, SDL_Window *window)
 void
 SWITCH_SetWindowSize(_THIS, SDL_Window *window)
 {
+#ifdef SDL_VIDEO_OPENGL_EGL
     u32 w = 0, h = 0;
     SDL_WindowData *data = (SDL_WindowData *) window->driverdata;
     SDL_GLContext ctx = SDL_GL_GetCurrentContext();
@@ -311,6 +318,7 @@ SWITCH_SetWindowSize(_THIS, SDL_Window *window)
             SDL_EGL_MakeCurrent(_this, data->egl_surface, ctx);
         }
     }
+#endif
 }
 void
 SWITCH_ShowWindow(_THIS, SDL_Window *window)

--- a/src/video/switch/SDL_switchvideo.h
+++ b/src/video/switch/SDL_switchvideo.h
@@ -22,19 +22,18 @@
 #ifndef __SDL_SWITCHVIDEO_H__
 #define __SDL_SWITCHVIDEO_H__
 
-#if SDL_VIDEO_DRIVER_SWITCH
-
 #include <switch.h>
 
 #include "../../SDL_internal.h"
 #include "../SDL_sysvideo.h"
-
+#ifdef SDL_VIDEO_OPENGL_EGL
 #include "SDL_egl.h"
 
 typedef struct SDL_WindowData
 {
     EGLSurface egl_surface;
 } SDL_WindowData;
+#endif
 
 int SWITCH_VideoInit(_THIS);
 void SWITCH_VideoQuit(_THIS);
@@ -56,7 +55,6 @@ void SWITCH_SetWindowGrab(_THIS, SDL_Window *window, SDL_bool grabbed);
 void SWITCH_DestroyWindow(_THIS, SDL_Window *window);
 void SWITCH_PumpEvents(_THIS);
 
-#endif /* SDL_VIDEO_DRIVER_SWITCH */
 #endif /* __SDL_SWITCHVIDEO_H__ */
 
 /* vi: set ts=4 sw=4 expandtab: */


### PR DESCRIPTION
1. check with 'if defined' instead of 'if' for SDL_driver_ and __SWITCH__
- the audio and video drivers are currently a mix, but they already changed to defineds in SDL2-head
- the threads are opengl are currently 'if', but they are changed to defineds in SDL2-head
2. protect opengl-code with SDL_VIDEO_OPENGL_EGL
3. SDL_VIDEO_DRIVER_platform_ check in video/_platform_/ is usually omitted (except for video.c for some reason)