### PR TITLE
switch [sdl2]: access joystick->instance_id directly

### DIFF
--- a/src/joystick/switch/SDL_sysjoystick.c
+++ b/src/joystick/switch/SDL_sysjoystick.c
@@ -266,7 +266,7 @@ static int SWITCH_JoystickSetSensorsEnabled(SDL_Joystick *joystick, SDL_bool ena
  */
 static void SWITCH_JoystickUpdate(SDL_Joystick *joystick) {
     u64 diff;
-    int index = (int) SDL_JoystickInstanceID(joystick);
+    int index = joystick->instance_id;
     if (index >= JOYSTICK_COUNT || SDL_IsTextInputActive()) {
         return;
     }


### PR DESCRIPTION
access joystick->instance_id directly (instead of SDL_JoystickInstanceID)
