### PR TITLE
Wii U: Fix ProcUI cleanup for shutdown.

### DIFF
--- a/src/video/wiiu/SDL_wiiuvideo.h
+++ b/src/video/wiiu/SDL_wiiuvideo.h
@@ -39,6 +39,8 @@ struct WIIU_VideoData
 
 	SDL_bool hasForeground;
 	SDL_bool enteringBackground;
+	// indicate if ProcUI received PROCUI_STATUS_EXITING
+	SDL_bool exitingProcUI;
 
 	void *commandBufferPool;
 


### PR DESCRIPTION
This fixes ProcUI cleanup during a console shutdown.

The previous code made the assumption that `ProcUIInShutdown()` indicated if the `EXITING` message had been received. That was true only if the console was **not** shutting down; when the power button is pressed (or APD kicks in), that function can return `true` earlier than the `EXITING` message.

The driver data now keeps a flag (`exitingProcUI`) to indicate if `EXITING` has been received.

This code was tested in the following cases:
- closing app from the Home Button Menu;
- premature stop of event loop (before `SDL_QUIT` is generated), which executes the extra cleanup code;
- console shutdown;
- console shutdown when the app uses `OSEnableForegroundExit()` (no transition to background before the exit message.)