### PR TITLE
ogc: update signature of resetcallback

### DIFF
--- a/src/main/wii/SDL_wii_main.c
+++ b/src/main/wii/SDL_wii_main.c
@@ -46,7 +46,7 @@ static void ShutdownCB()
     OGC_PowerOffRequested = true;
 }
 
-static void ResetCB()
+static void ResetCB(u32 /* irq */, void * /* context */)
 {
     OGC_ResetRequested = true;
 }


### PR DESCRIPTION
The type of the resetcallback function in libogc was changed in 2018, to add the IRQ and context paramters. For some reason, though, the mismatch was not reported by the previous compilers.

```
/home/mardy/src/git/gamedev/2SDL/src/main/wii/SDL_wii_main.c:70:26: error: passing argument 1 of 'SYS_SetResetCallback' from incompatible pointer type [-Wincompatible-pointer-types]
   70 |     SYS_SetResetCallback(ResetCB);
      |                          ^~~~~~~
      |                          |
      |                          void (*)(void)
In file included from /opt/devkitpro/libogc/include/gccore.h:62,
                 from /opt/devkitpro/libogc/include/ogcsys.h:4,
                 from /home/mardy/src/git/gamedev/2SDL/src/main/wii/SDL_wii_main.c:40:
/opt/devkitpro/libogc/include/ogc/system.h:384:50: note: expected 'resetcallback' {aka 'void (*)(unsigned int,  void *)'} but argument is of type 'void (*)(void)'
  384 | resetcallback SYS_SetResetCallback(resetcallback cb);
      |                                    ~~~~~~~~~~~~~~^~
/home/mardy/src/git/gamedev/2SDL/src/main/wii/SDL_wii_main.c:49:13: note: 'ResetCB' declared here
   49 | static void ResetCB()
      |             ^~~~~~~
/opt/devkitpro/libogc/include/ogc/system.h:251:16: note: 'resetcallback' declared here
  251 | typedef void (*resetcallback)(u32 irq, void* ctx);
      |                ^~~~~~~~~~~~~
```
