### PR TITLE
SDL_system/wiiu: add preprocessor define for swkbd API version

### DIFF
--- a/include/SDL_system.h
+++ b/include/SDL_system.h
@@ -614,6 +614,21 @@ extern DECLSPEC int SDLCALL SDL_GDKGetTaskQueue(XTaskQueueHandle * outTaskQueue)
 
 /* Platform specific functions for Wii U */
 #if defined(__WIIU__)
+
+/**
+ * Preprocessor define for the swkbd API version.
+ *
+ * This number should be bumped any time there are changes to the API
+ * to allow programs to retain source-level compatibility whenever
+ * changes are made.
+ *
+ * For example:
+ *   #if SDL_WIIU_SWKBD_API == 1
+ *       SDL_WiiUSetSWKBDEnabled(SDL_FALSE);
+ *   #endif
+ */
+# define SDL_WIIU_SWKBD_API 1
+
 typedef enum SDL_WiiUSysWMEventType {
     /** Sent before any text input event. */
     SDL_WIIU_SYSWM_SWKBD_OK_START_EVENT = 1,


### PR DESCRIPTION
## Description
This adds a preprocessor define that describes the swkbd API. The rationale being that there are programs that desire only USB keyboard support, but also wish to retain source-level compatibility with pre-swkbd WiiU SDL versions. For example, Schism Tracker completely breaks when a software keyboard is pulled up.