### PR TITLE
Wii U: Removed SDL_WiiUSetSWKBDEnabled()

### DIFF
--- a/include/SDL_system.h
+++ b/include/SDL_system.h
@@ -42,7 +42,7 @@ extern "C" {
 
 /* Platform specific functions for Windows */
 #if defined(__WIN32__) || defined(__GDK__)
-
+	
 typedef void (SDLCALL * SDL_WindowsMessageHook)(void *userdata, void *hWnd, unsigned int message, Uint64 wParam, Sint64 lParam);
 
 /**
@@ -182,9 +182,9 @@ extern DECLSPEC int SDLCALL SDL_LinuxSetThreadPriority(Sint64 threadID, int prio
  * \since This function is available since SDL 2.0.18.
  */
 extern DECLSPEC int SDLCALL SDL_LinuxSetThreadPriorityAndPolicy(Sint64 threadID, int sdlPriority, int schedPolicy);
-
+ 
 #endif /* __LINUX__ */
-
+	
 /* Platform specific functions for iOS */
 #ifdef __IPHONEOS__
 

--- a/include/SDL_system.h
+++ b/include/SDL_system.h
@@ -42,7 +42,7 @@ extern "C" {
 
 /* Platform specific functions for Windows */
 #if defined(__WIN32__) || defined(__GDK__)
-	
+
 typedef void (SDLCALL * SDL_WindowsMessageHook)(void *userdata, void *hWnd, unsigned int message, Uint64 wParam, Sint64 lParam);
 
 /**
@@ -182,9 +182,9 @@ extern DECLSPEC int SDLCALL SDL_LinuxSetThreadPriority(Sint64 threadID, int prio
  * \since This function is available since SDL 2.0.18.
  */
 extern DECLSPEC int SDLCALL SDL_LinuxSetThreadPriorityAndPolicy(Sint64 threadID, int sdlPriority, int schedPolicy);
- 
+
 #endif /* __LINUX__ */
-	
+
 /* Platform specific functions for iOS */
 #ifdef __IPHONEOS__
 
@@ -622,16 +622,6 @@ typedef enum SDL_WiiUSysWMEventType {
     /** Sent after the swkbd was canceled. */
     SDL_WIIU_SYSWM_SWKBD_CANCEL_EVENT
 } SDL_WiiUSysWMEventType;
-
-/**
- * Disable the swkbd.
- *
- * Use this function if you only want text input from a physical USB keyboard.
- *
- * \param enabled `SDL_FALSE` if you do not want the swkbd to show up after calling
- * `SDL_StartTextInput()`.
- */
-extern DECLSPEC void SDLCALL SDL_WiiUSetSWKBDEnabled(SDL_bool enabled);
 
 /**
  * Select the swkbd keyboard mode.

--- a/src/video/wiiu/SDL_wiiuswkbd.cpp
+++ b/src/video/wiiu/SDL_wiiuswkbd.cpp
@@ -194,8 +194,6 @@ namespace
 
         } // namespace appear
 
-        bool enabled = true;
-
         raw_string swkbdLocale;
 
         nn::swkbd::ControllerInfo controllerInfo;
@@ -506,9 +504,6 @@ void WIIU_SWKBD_Initialize(void)
     if (detail::create::created)
         return;
 
-    if (!detail::enabled)
-        return;
-
     if (!detail::fsLib)
         detail::fsLib.emplace();
 
@@ -574,9 +569,6 @@ void WIIU_SWKBD_Calc(void)
     if (!detail::create::created)
         return;
 
-    if (!detail::enabled)
-        return;
-
     nn::swkbd::Calc(detail::controllerInfo);
     detail::controllerInfo = {};
 
@@ -630,9 +622,6 @@ void WIIU_SWKBD_Draw(SDL_Window *window)
     if (window != detail::appear::window)
         return;
 
-    if (!detail::enabled)
-        return;
-
     nn::swkbd::State state = nn::swkbd::GetStateInputForm();
     if (state == nn::swkbd::State::Hidden)
         return;
@@ -645,16 +634,11 @@ void WIIU_SWKBD_Draw(SDL_Window *window)
 
 SDL_bool WIIU_SWKBD_HasScreenKeyboardSupport(_THIS)
 {
-    if (!detail::enabled)
-        return SDL_FALSE;
     return SDL_TRUE;
 }
 
 void WIIU_SWKBD_ShowScreenKeyboard(_THIS, SDL_Window *window)
 {
-    if (!detail::enabled)
-        return;
-
     WIIU_SWKBD_Initialize();
 
     if (!detail::appear::window)
@@ -736,18 +720,6 @@ SDL_bool WIIU_SWKBD_IsScreenKeyboardShown(_THIS, SDL_Window *window)
         return SDL_TRUE;
 
     return SDL_FALSE;
-}
-
-void SDL_WiiUSetSWKBDEnabled(SDL_bool enabled)
-{
-    if (detail::enabled != !!enabled) {
-        detail::enabled = enabled;
-        if (!detail::enabled) {
-            // If application is turning swkbd off, we better free up all memory too.
-            WIIU_SWKBD_Finalize();
-            detail::create::cleanup();
-        }
-    }
 }
 
 void SDL_WiiUSetSWKBDKeyboardMode(SDL_WiiUSWKBDKeyboardMode mode)


### PR DESCRIPTION
This removes `SDL_WiiUSetSWKBDEnabled()`. The same behavior can be achieved with the `SDL_HINT_ENABLE_SCREEN_KEYBOARD` hint. It's a bit more convoluted, but consistent across all backends that have on-screen keyboard implementations.