### PR TITLE
Wii U: fixed the test to ignore USB keyboard events while swkbd is shown.

### DIFF
--- a/src/video/wiiu/SDL_wiiukeyboard.c
+++ b/src/video/wiiu/SDL_wiiukeyboard.c
@@ -81,7 +81,7 @@ static void WIIU_SendKeyEventText(KBDKeyEvent *e)
 		utf8[1] = 0x80 | ((symbol >> 6) & 0x3F);
 		utf8[2] = 0x80 |  (symbol & 0x3F);
 	}
-	
+
 	SDL_SendKeyboardText((char *)utf8);
 }
 
@@ -92,7 +92,7 @@ void SDL_WIIU_PumpKeyboardEvents(_THIS)
 	SDL_LockMutex(event_buffer_mutex);
 
 	/* only generate keyboard and text events if swkbd is not visible */
-	if (!WIIU_SWKBD_IsScreenKeyboardShown(NULL, NULL)) {
+	if (!WIIU_SWKBD_IsScreenKeyboardShown(_this, NULL)) {
 		/* process each key event */
 		for (i = 0; i < event_buffer.current; i++) {
 			SDL_SendKeyboardKey(
@@ -104,7 +104,7 @@ void SDL_WIIU_PumpKeyboardEvents(_THIS)
 				WIIU_SendKeyEventText(&event_buffer.events[i]);
 		}
 	}
-	
+
 	/* reset the buffer */
 	event_buffer.current = 0;
 

--- a/src/video/wiiu/SDL_wiiuswkbd.cpp
+++ b/src/video/wiiu/SDL_wiiuswkbd.cpp
@@ -712,7 +712,8 @@ SDL_bool WIIU_SWKBD_IsScreenKeyboardShown(_THIS, SDL_Window *window)
     if (!detail::create::created)
         return SDL_FALSE;
 
-    if (window != detail::appear::window)
+    // Only match for the correct window when window is not null.
+    if (window && window != detail::appear::window)
         return SDL_FALSE;
 
     nn::swkbd::State state = nn::swkbd::GetStateInputForm();


### PR DESCRIPTION
This fixes a bug with the test that drops USB keyboard events while the swkbd is shown.

`WIIU_SWKBD_IsScreenKeyboardShown()` was modified to accept a null window argument.

This will not affect the behavior of the public API `SDL_IsScreenKeyboardShown()` because it has a check against a null window.