### PR TITLE
main: initialize the keyboard from within the video module

### DIFF
--- a/src/main/wii/SDL_wii_main.c
+++ b/src/main/wii/SDL_wii_main.c
@@ -38,7 +38,6 @@
 #include <fat.h>
 #include <ogc/usbmouse.h>
 #include <ogcsys.h>
-#include <wiikeyboard/keyboard.h>
 #include <wiiuse/wpad.h>
 
 static void ShutdownCB()
@@ -73,7 +72,6 @@ int main(int argc, char *argv[])
     WPAD_SetVRes(WPAD_CHAN_ALL, 640, 480);
 
     MOUSE_Init();
-    KEYBOARD_Init(NULL);
     fatInitDefault();
 
     /* Call the user's main function. Make sure that argv contains at least one

--- a/src/video/ogc/SDL_ogcvideo.c
+++ b/src/video/ogc/SDL_ogcvideo.c
@@ -41,6 +41,7 @@
 #include <ogc/gx.h>
 #include <ogc/system.h>
 #include <ogc/video.h>
+#include <wiikeyboard/keyboard.h>
 
 #include <opengx.h>
 
@@ -315,6 +316,8 @@ int OGC_VideoInit(_THIS)
 
 #ifdef __wii__
     OGC_InitMouse(_this);
+    /* OGC_PumpEvents reads the keyboard, so we need to initialize it here */
+    KEYBOARD_Init(NULL);
 #endif
     return 0;
 }


### PR DESCRIPTION
The keyboard is being read from OGC_PumpEvents, which is part of the video subsystem. Therefore ensure that it's initialized in that subsystem, and not in SDL_main.

This fixes a bug where an application not using our SDL main would access invalid memory areas due to the keyboard not being initialized.
