### PR TITLE
switch-sdl-3.4: Add platform name in SDL_GetPlatform

### DIFF
--- a/src/SDL.c
+++ b/src/SDL.c
@@ -798,6 +798,8 @@ const char *SDL_GetPlatform(void)
     return "GNU/Hurd";
 #elif defined(__managarm__)
     return "Managarm";
+#elif defined(SDL_PLATFORM_SWITCH)
+    return "Nintendo Switch";
 #else
     return "Unknown (see SDL_platform.h)";
 #endif


### PR DESCRIPTION
Adds a platform name for the Nintendo Switch in SDL_GetPlatform