### PR TITLE
switch-sdl-3.4: Only send keyboard key events when state changes

### DIFF
--- a/src/video/switch/SDL_switchkeyboard.c
+++ b/src/video/switch/SDL_switchkeyboard.c
@@ -49,10 +49,11 @@ void SWITCH_PollKeyboard(Uint64 timestamp)
             bool pressed = hidKeyboardStateGetKey(&state, (int)scancode);
             if (pressed && !keys[scancode]) {
                 keys[scancode] = true;
+                SDL_SendKeyboardKey(timestamp, keyboard_id, pressed, scancode, keys[scancode]);
             } else if (!pressed && keys[scancode]) {
                 keys[scancode] = false;
+                SDL_SendKeyboardKey(timestamp, keyboard_id, pressed, scancode, keys[scancode]);
             }
-            SDL_SendKeyboardKey(timestamp, keyboard_id, pressed, scancode, keys[scancode]);
         }
     }
 }


### PR DESCRIPTION
Previously it would constantly send key down events, while we will only want to send a key event to SDL when the state of a key actually changes.

(Note: Only tested on emulator)