### PR TITLE
Add switch locale functions + compilation fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3454,6 +3454,9 @@ elseif(NINTENDO_SWITCH)
     set(HAVE_CLOCK_GETTIME 1)
   endif()
 
+  sdl_glob_sources("${SDL3_SOURCE_DIR}/src/locale/switch/*.c")
+  set(HAVE_SDL_LOCALE TRUE)
+
   set(SDL_TIMER_SWITCH 1)
   sdl_glob_sources("${SDL3_SOURCE_DIR}/src/timer/switch/*.c")
   set(HAVE_SDL_TIMERS TRUE)

--- a/include/SDL3/SDL_egl.h
+++ b/include/SDL3/SDL_egl.h
@@ -494,6 +494,12 @@ typedef void              *EGLNativeDisplayType;
 typedef khronos_uintptr_t  EGLNativePixmapType;
 typedef khronos_uintptr_t  EGLNativeWindowType;
 
+#elif defined(__SWITCH__)
+
+typedef int   EGLNativeDisplayType;
+typedef void *EGLNativePixmapType;
+typedef void *EGLNativeWindowType;
+
 #else
 #error "Platform not recognized"
 #endif

--- a/src/locale/switch/SDL_syslocale.c
+++ b/src/locale/switch/SDL_syslocale.c
@@ -1,0 +1,113 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 2026 p-sam
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#include "SDL_internal.h"
+#include "../SDL_syslocale.h"
+
+#include <switch.h>
+
+static SetLanguage getSwitchSystemLanguage(void) {
+    Result rc = setInitialize();
+
+    if(R_SUCCEEDED(rc)) {
+
+        u64 code;
+        rc = setGetSystemLanguage(&code);
+
+        SetLanguage language;
+        if(R_SUCCEEDED(rc)) {
+            rc = setMakeLanguage(code, &language);
+        }
+
+        setExit();
+
+        if(R_SUCCEEDED(rc)) {
+            return language;
+        }
+    }
+
+    return SetLanguage_Total;
+}
+
+bool SDL_SYS_GetPreferredLocales(char *buf, size_t buflen) {
+    switch(getSwitchSystemLanguage()) {
+        case SetLanguage_JA:
+            SDL_strlcpy(buf, "ja_JP", buflen);
+            break;
+        case SetLanguage_FR:
+            SDL_strlcpy(buf, "fr_FR", buflen);
+            break;
+        case SetLanguage_DE:
+            SDL_strlcpy(buf, "de_DE", buflen);
+            break;
+        case SetLanguage_IT:
+            SDL_strlcpy(buf, "it_IT", buflen);
+            break;
+        case SetLanguage_ES:
+            SDL_strlcpy(buf, "es_ES", buflen);
+            break;
+        case SetLanguage_ZHCN:
+            SDL_strlcpy(buf, "zh_CN", buflen);
+            break;
+        case SetLanguage_KO:
+            SDL_strlcpy(buf, "ko_KR", buflen);
+            break;
+        case SetLanguage_NL:
+            SDL_strlcpy(buf, "nl_NL", buflen);
+            break;
+        case SetLanguage_PT:
+            SDL_strlcpy(buf, "pt_PT", buflen);
+            break;
+        case SetLanguage_RU:
+            SDL_strlcpy(buf, "ru_RU", buflen);
+            break;
+        case SetLanguage_ZHTW:
+            SDL_strlcpy(buf, "zh_TW", buflen);
+            break;
+        case SetLanguage_ENGB:
+            SDL_strlcpy(buf, "en_GB", buflen);
+            break;
+        case SetLanguage_FRCA:
+            SDL_strlcpy(buf, "fr_CA", buflen);
+            break;
+        case SetLanguage_ES419:
+            SDL_strlcpy(buf, "es_419", buflen);
+            break;
+        case SetLanguage_ZHHANS:
+            break;
+            SDL_strlcpy(buf, "zh_CN", buflen);
+            break;
+        case SetLanguage_ZHHANT:
+            SDL_strlcpy(buf, "zh_TW", buflen);
+            break;
+        case SetLanguage_PTBR:
+            SDL_strlcpy(buf, "pt_BR", buflen);
+            break;
+        case SetLanguage_ENUS:
+        default:
+            SDL_strlcpy(buf, "en_US", buflen);
+            break;
+    }
+
+    return true;
+}
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/src/power/SDL_power.c
+++ b/src/power/SDL_power.c
@@ -71,7 +71,7 @@ static SDL_GetPowerInfo_Impl implementations[] = {
 #ifdef SDL_POWER_N3DS // handles N3DS.
     SDL_GetPowerInfo_N3DS,
 #endif
-#ifdef SDL_POWER_SWITCH // handles N3DS.
+#ifdef SDL_POWER_SWITCH // handles Switch.
     SDL_GetPowerInfo_SWITCH,
 #endif
 #ifdef SDL_POWER_EMSCRIPTEN // handles Emscripten

--- a/src/video/switch/SDL_switchkeyboard.c
+++ b/src/video/switch/SDL_switchkeyboard.c
@@ -18,6 +18,9 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
+
+#include "SDL_internal.h"
+
 #if SDL_VIDEO_DRIVER_SWITCH
 
 #include <switch.h>

--- a/src/video/switch/SDL_switchmouse.c
+++ b/src/video/switch/SDL_switchmouse.c
@@ -19,6 +19,8 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
+#include "SDL_internal.h"
+
 #if SDL_VIDEO_DRIVER_SWITCH
 
 #include <switch.h>

--- a/src/video/switch/SDL_switchopengles.c
+++ b/src/video/switch/SDL_switchopengles.c
@@ -18,6 +18,8 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
+
+#include "SDL_internal.h"
 #include "../../SDL_log_c.h"
 
 #if SDL_VIDEO_DRIVER_SWITCH

--- a/src/video/switch/SDL_switchtouch.c
+++ b/src/video/switch/SDL_switchtouch.c
@@ -18,6 +18,7 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
+
 #include "SDL_internal.h"
 
 #if SDL_VIDEO_DRIVER_SWITCH

--- a/src/video/switch/SDL_switchvideo.c
+++ b/src/video/switch/SDL_switchvideo.c
@@ -19,6 +19,8 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
+#include "SDL_internal.h"
+
 #if SDL_VIDEO_DRIVER_SWITCH
 
 #include "../../events/SDL_keyboard_c.h"


### PR DESCRIPTION
Fixes + switch locale functions

## Description
* Adds support for `SDL_GetPreferredLocales()`  returning the code based on the switch system language
* Compilations fixes
* Fixes a small typo in a comment

---------------------------------

I have a few other changes not included that I would like to discuss to see if they can get merged:
* Rebase to 3.4.12 + [another simple compat fix](https://github.com/p-sam/SDL/commit/36cacb2e5def5da61c52ff91a87ae877c4ecf5e1)
* [Audout audio driver](https://github.com/p-sam/SDL/blob/switch-sdl-3.4-audout/src/audio/switch/SDL_switchaudio.c) potentially in a separate `switch-sdl-3.4-audout` branch just like `switch-sdl-2.28-audout`, the driver was ported because of how much it improved performance on Taisei Project compared to the current `audren` based one in this branch